### PR TITLE
More succinct way to println AggregationOutput

### DIFF
--- a/source/tutorial/use-aggregation-framework-with-java-driver.txt
+++ b/source/tutorial/use-aggregation-framework-with-java-driver.txt
@@ -131,7 +131,7 @@ Let’s take a look at the results of my audit:
 
 .. code-block:: java
 
-   System.out.println(output.getCommandResult());
+   System.out.println(output);
 
 .. code-block:: sh
 


### PR DESCRIPTION
AggregationOutput.toString() appears equivalent to AggregationOutput.getCommandResult().toString(),
so I would omit the unnecessary code, unless we also wish to draw readers attention to the existence of AggregationOutput.getCommandResult()
