### PR TITLE
Update getting-started-with-csharp-driver.txt

### DIFF
--- a/source/tutorial/getting-started-with-csharp-driver.txt
+++ b/source/tutorial/getting-started-with-csharp-driver.txt
@@ -179,7 +179,7 @@ In this example we will read back an ``Entity`` assuming we know the
 
 .. code-block:: csharp
 
-   var query = Query<Entity>(e => e.Id, id);
+   var query = Query<Entity>.EQ(e => e.Id, id);
    var entity = collection.FindOne(query);
 
 ``Query<Entity>.EQ`` uses the ``Query<T>`` builder class to build the


### PR DESCRIPTION
You forgot ".EQ" in "Find an Existing Document" example:

var query = Query<Entity>.EQ(e => e.Id, id);
