### PR TITLE
Update scala.txt

### DIFF
--- a/source/drivers/scala.txt
+++ b/source/drivers/scala.txt
@@ -51,6 +51,8 @@ Community
   Scala-based, asynchronous Netty driver for MongoDB with type-class
   based fast custom object encoding.
 
+- `frontlets https://github.com/riedelcastro/frontlets`_  lightweight typed wrappers around scala maps, with strong mongo support and json integration. Supports type-safe queries in spirit of the original mongo collection interface, object graph traversal, immutable objects and more.  
+
 .. removed webcast, unplayable
 .. metadata:  <object seamlesstabbing="false"
    class="BrightcoveExperience" id="myExperience620186085001"


### PR DESCRIPTION
I added description of [frontlets](https://github.com/riedelcastro/frontlets), a lightweight framework of typed scala map wrappers. They tightly integrated with mongo, and allow type-safe querying of mongo collections. 
