### PR TITLE
Point at a newer version of mongodb (2.4.3 instead of 1.0.1)

### DIFF
--- a/source/platforms/amazon-ec2.txt
+++ b/source/platforms/amazon-ec2.txt
@@ -79,9 +79,9 @@ root.  For example on 64 bit Linux:
 
 .. code-blocK:: sh
 
-   [~]$ curl -O http://downloads.mongodb.org/linux/mongodb-linux-x86_64-1.0.1.tgz
-   [~]$ tar -xzf mongodb-linux-x86_64-1.0.1.tgz
-   [~]$ cd mongodb-linux-x86_64-1.0.1/bin
+   [~]$ curl -O http://downloads.mongodb.org/linux/mongodb-linux-x86_64-2.4.3.tgz
+   [~]$ tar -xzf mongodb-linux-x86_64-2.4.3.tgz
+   [~]$ cd mongodb-linux-x86_64-2.4.3.tgz/bin
    [bin]$ ./mongod --version
 
 Before running the database one should decide where to put


### PR DESCRIPTION
I only realized this was pointing to a stale version because commands in the rest of this document don't work on version 1.0.1.

Even better would be to point to a URL that always points to the latest stable version, if such a URL exists.
