### PR TITLE
Fixing minor typos

### DIFF
--- a/source/tutorial/install-mongodb-on-amazon-ec2.txt
+++ b/source/tutorial/install-mongodb-on-amazon-ec2.txt
@@ -456,7 +456,7 @@ Install and Configure MongoDB
 .. note::
 
    If you created a MongoDB instance via the AWS Marketplace, skip ahead
-   to [#Starting MongoDB] below.
+   to :ref:`ec2-starting-mongodb` below.
 
 Now that the storage has been configured, we need to install and
 configure MongoDB to use the storage we've set up, then set it to start


### PR DESCRIPTION
Fixing minor typos: closing parenthesis missing and coherent use of e.g. abbreviation.
