### PR TITLE
Update perl.txt

### DIFF
--- a/source/drivers/perl.txt
+++ b/source/drivers/perl.txt
@@ -42,7 +42,57 @@ generated after every commit.
 You can see if it is a good time to grab the bleeding edge code by
 seeing if the `build is green <http://buildbot.mongodb.org/waterfall>`_.
 
-To build the driver, run:
+The Perl driver requires some libraries available in CPAN. As of August,
+2013, these are: 
+
+.. code-block:: sh
+
+   Data::Types
+   DateTime
+   DateTime::Tiny
+   ExtUtils::MakeMaker
+   File::Slurp
+   File::Temp
+   FileHandle
+   JSON
+   Test::Exception
+   Test::Warn
+   Tie::IxHash
+   Try::Tiny
+   boolean
+   ExtUtils::MakeMaker
+   Class::Method::Modifiers
+   DateTime
+   Digest::MD5
+   Moose
+   Tie::IxHash
+   XSLoader
+
+In order to install the dependencies, first copy the names of the
+packages into a text file, packages.txt. Then run the following:
+
+.. code-block:: sh
+
+   sudo cpan App::cpanminus
+   cat packages.txt | sudo cpanm
+
+Before you are able to build the MongoDB module, you'll also need
+Dist::Zilla. Get Dist::Zilla and its dependencies with the following:
+
+.. code-block:: sh
+
+   sudo cpan Dist::Zilla
+   dzil authordeps | sudo cpanm
+
+Next, use Dist::Zilla to create a copy of the driver module with the
+correct version information:
+
+.. code-block:: sh
+
+   dzil build
+
+This will create a new directory named something like MongoDB-0.702.1.
+To build and install the driver, change to this directory and run:
 
 .. code-block:: sh
 
@@ -52,17 +102,6 @@ To build the driver, run:
    sudo make install
 
 The tests will not pass without a :program:`mongod` process running.
-
-The Perl driver requires some libraries available in CPAN. As of April,
-2010, these are Any::Moose, Class::Method::Modifiers, Data::Types,
-DateTime, File::Slurp, Test::Exception, Try::Tiny, boolean, and
-Module::Install. (Additionally, Tie::IxHash is required for testing.) On
-Debian or Ubuntu systems, these prerequisites can be easily installed
-with the following command:
-
-.. code-block:: sh
-
-   sudo apt-get install libmodule-install-perl libany-moose-perl libclass-method-modifiers-perl libdata-types-perl libdatetime-perl libfile-slurp-perl libtest-exception-perl libtry-tiny-perl libboolean-perl libtie-ixhash-perl
 
 Big-Endian Systems
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The ecosystem doc for installing the Perl driver manually was out of date. I updated the text to reflect the new process.
