### PR TITLE
Adding PlayORM as a 3rd party framework

### DIFF
--- a/source/drivers/java.txt
+++ b/source/drivers/java.txt
@@ -67,6 +67,9 @@ POJO Mappers
    Query in Java as in :program:`mongo` shell (using strings),
    unmarshall results into Java objects (using Jackson)
 
+- `PlayORM`_
+      An object NoSQL mapping solution so you can write POJO’s and let it deal with all the details of marshalling/unmarshalling to MongoDB.
+      
 .. _`Morphia - Type-Safe Wrapper with DAO/Datastore abstractions`:
    http://code.google.com/p/morphia/
 
@@ -84,6 +87,8 @@ POJO Mappers
    https://github.com/vznet/mongo-jackson-mapper
 
 .. _`Kundera`: http://kundera.googlecode.com
+
+.. _`PlayORM`: https://github.com/deanhiller/playorm
 
 .. _`Jongo`: http://www.jongo.org/
 


### PR DESCRIPTION
As PlayORM has started supported MongoDB, I am adding it into the list of 3rd party libraries.