### PR TITLE
switched node.js interface

### DIFF
--- a/source/tools/http-interfaces.txt
+++ b/source/tools/http-interfaces.txt
@@ -17,12 +17,10 @@ DrowsyDromedary (Ruby)
 `DrowsyDromedary <https://github.com/zuk/DrowsyDromedary>`_
 is a REST layer for MongoDB based on Ruby.
 
-MongoDB Rest (Node.js)
+RESTful MongoDB (Node.js)
 ~~~~~~~~~~~~~~~~~~~~~~
-
-`MongoDB Rest <https://github.com/tdegrunt/mongodb-rest>`_
-is an **alpha** REST interface to MongoDB that uses the
-`MongoDB Node Native driver <https://github.com/christkv/node-mongodb-native>`_.
+`RESTful MongoDB <https://github.com/bitliner/restful-mongo>`
+is a REST interface for MongoDB in Node.js based on `MongoDB Rest <https://github.com/tdegrunt/mongodb-rest>`.
 
 Mongodb Java REST server
 ~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
removed an outdated/abandoned node.js interface, replacing it with the maintained fork.
