### PR TITLE
Fix: monthly to minute

### DIFF
--- a/source/use-cases/pre-aggregated-reports.txt
+++ b/source/use-cases/pre-aggregated-reports.txt
@@ -116,7 +116,7 @@ This approach has a couple of advantages:
 
 There are, however, significant issues with this approach. The most
 significant issue is that, as you :term:`upsert` data into the
-``hourly`` and ``monthly`` fields, the document grows. Although
+``hourly`` and ``minute`` fields, the document grows. Although
 MongoDB will pad the space allocated to documents, it must still will
 need to reallocate these documents multiple times throughout the day,
 which impacts performance.


### PR DESCRIPTION
In the document described, there is no field called monthly. The problem described (adding new field multiple times, leading to increasing document size) would occur when updating the minute field, not when updating a monthly field.
