### PR TITLE
Include Link to JDBC Driver for MongoDB

### DIFF
--- a/source/drivers/java.txt
+++ b/source/drivers/java.txt
@@ -126,6 +126,10 @@ Misc
 - `mongo-java-logging`_
      a Java logging handler
 
+- `JDBC Driver for MongoDB`_
+   JDBC Driver for MongoDB includes SQL support for joins, aggregation, and 
+   subqueries and works with any application supporting JDBC.
+   
 * `(Experimental, Type4) JDBC driver`_
 
 * `Metamodel data exploration and querying library`_
@@ -139,6 +143,9 @@ Misc
 
 .. _`mongo-java-logging`: https://github.com/deftlabs/mongo-java-logging
 
+.. _`JDBC Driver for MongoDB`:
+   http://www.unityjdbc.com/mongojdbc/
+   
 .. _`(Experimental, Type4) JDBC driver`:
    http://github.com/erh/mongo-jdbc
 


### PR DESCRIPTION
The free JDBC Driver for MongoDB allows SQL queries including joins, aggregation, and subqueries to be performed.
