### PR TITLE
mongo-jackson-mapper is now Mongojack

### DIFF
--- a/source/drivers/java.txt
+++ b/source/drivers/java.txt
@@ -56,7 +56,7 @@ POJO Mappers
 - `lib-mongomapper`_
       JavaBean Mapper (No annotations)
 
-- `mongo-jackson-mapper`_
+- `MongoJack`_
       Uses jackson (annotations) to map to/from POJOs and has a simple
       wrapper around ``DBCollection`` to simply this.
 
@@ -83,8 +83,8 @@ POJO Mappers
 
 .. _`lib-mongomapper`: https://github.com/dadastream/lib-mongomapper
 
-.. _`mongo-jackson-mapper`:
-   https://github.com/vznet/mongo-jackson-mapper
+.. _`MongoJack`:
+   http://mongojack.org/
 
 .. _`Kundera`: http://kundera.googlecode.com
 


### PR DESCRIPTION
Changed the name and switched to the new URL
