### PR TITLE
Don't reference obsolete header only usage of bson

### DIFF
--- a/source/drivers/cpp.txt
+++ b/source/drivers/cpp.txt
@@ -70,9 +70,7 @@ See :ref:`BSON examples in the Getting Started guide <getting-started-bson-examp
 Standalone Usage
 ~~~~~~~~~~~~~~~~
 
-You can use the C++ BSON library without MongoDB. Most BSON methods
-under the ``bson/`` directory are header-only. They require ``boost``, but
-headers only.
+You can use the C++ BSON library without MongoDB by including the mongo/bson/bson.h header.
 
 See the `bsondemo.cpp example at github.com <https://github.com/mongodb/mongo/blob/master/src/mongo/bson/bsondemo/bsondemo.cpp>`_
 


### PR DESCRIPTION
Remove language that suggests that even the bson subset of the driver is expected to work header only.
