### PR TITLE
Expand db example and update css link reference

### DIFF
--- a/source/tutorial/write-a-tumblelog-application-with-flask-mongoengine.txt
+++ b/source/tutorial/write-a-tumblelog-application-with-flask-mongoengine.txt
@@ -1006,7 +1006,7 @@ drop down menu in the toolbar:
 
    {% block js_footer %}
      <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
-     <script src="http://twitter.github.com/bootstrap/1.4.0/bootstrap-dropdown.js"></script>
+     <script src="http://netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
    {% endblock %}
 
 


### PR DESCRIPTION
- Expand the example on connecting a database to include a real example with MongoHQ so that it's clearer on how to set this up.
- Update the now deprecated css link reference to the updated version for bootstrap 3.1.1
