### PR TITLE
Added 'MongoLid Laravel' to php-libraries.txt

### DIFF
--- a/source/drivers/php-libraries.txt
+++ b/source/drivers/php-libraries.txt
@@ -94,6 +94,10 @@ Laravel Framework
   <https://github.com/boparaiamrit/Laravel-Mandango>`_: An ODM for
   MongoDB, that integrates with the `Laravel <http://laravel.com>`_
   PHP Framework.
+  
+  - `MongoLid Laravel
+  <https://github.com/leroy-merlin-br/mongolid-laravel>`_: Easy, powerful and ultrafast MongoDB ODM for `Laravel <http://laravel.com>`_
+  Framework.
 
 Symfony 2
 ~~~~~~~~~


### PR DESCRIPTION
Added link and information about [MongoLid](https://github.com/leroy-merlin-br/mongolid-laravel) in the [Laravel Framework section](http://docs.mongodb.org/ecosystem/drivers/php-libraries/#laravel-framework)