### PR TITLE
perl.txt: add unstated build dependencies

### DIFF
--- a/source/drivers/perl.txt
+++ b/source/drivers/perl.txt
@@ -63,6 +63,8 @@ The Perl driver requires some libraries available in CPAN. As of September,
    Moose
    Tie::IxHash
    XSLoader
+   Config::AutoConf
+   Devel::Size
 
 In order to install the dependencies, first copy the names of the
 packages into a text file, packages.txt. Then run the following:


### PR DESCRIPTION
Against current HEAD of master branch of the perl driver, after following the instructions to install the dependencies, the `perl Makefile.PL` step still failed, requiring first Config::AutoConf, and then Devel::Size to fully run to completion successfully.  This was on an older Ubuntu distribution (13.04).
