### PR TITLE
The example captures an un-usable api call.

### DIFF
--- a/source/includes/table-sql-to-mongo-to-cpp-examples.yaml
+++ b/source/includes/table-sql-to-mongo-to-cpp-examples.yaml
@@ -56,9 +56,10 @@ mongo2: |
 cpp2: |
       .. code-block:: cpp
 
+         BSONObj b = BSON("a"<<1<<"b"<<1)
          auto_ptr<DBClientCursor> cursor =
            c.query("mydb.users", Query(), 
-           0, 0, BSON("a"<<1<<"b"<<1));
+           0, 0, &b);
 sql3: |
       .. code-block:: sql
 


### PR DESCRIPTION
The call expects a BSONObj\* while the example shows to pass BSONObj and fails to compile.
