### PR TITLE
Update use-csharp-driver.txt

### DIFF
--- a/source/tutorial/use-csharp-driver.txt
+++ b/source/tutorial/use-csharp-driver.txt
@@ -960,8 +960,9 @@ follows:
 
 1. If a connect mode is specified other than automatic, it is used.
 
-#. If a replica set name is specified on the connection string
-   (replicaset), then replicaset mode is used.
+#. If the option replicaset is specified on the connection string
+   using literal ``?connect=replicaset`` then replicaset mode is used.
+   Don’t use replica set name.
 
 #. If there is only one server listed on the connection string, then
    direct mode is used.


### PR DESCRIPTION
The original text suggests that you have to specify the replica set name in the connection string. Doing that you will get the error "Invalid key value pair".
Testcase:
The following connection contains valid replica set name and server names and throws that exception: "mongodb://Mongo1,Mongo2,Mongo3/?connect=set1". The same code with the following connection works well: "mongodb://Mongo1,Mongo2,Mongo3/?connect=replicaset"
