### PR TITLE
Correct document field

### DIFF
--- a/source/tutorial/use-aggregation-framework-with-java-driver.txt
+++ b/source/tutorial/use-aggregation-framework-with-java-driver.txt
@@ -154,7 +154,7 @@ code we’ll use to perform the aggregation task:
    DBObject group = new BasicDBObject("$group", groupFields);
 
    // Finally the $sort operation
-   DBObject sort = new BasicDBObject("$sort", new BasicDBObject("amount", -1));
+   DBObject sort = new BasicDBObject("$sort", new BasicDBObject("average", -1));
 
    // run aggregation
    List<DBObject> pipeline = Arrays.asList(match, project, group, sort);


### PR DESCRIPTION
The result of the `$group` operation is the document with `_id` and `average` keys. Therefore, the `$sort` operation should be realized on the `average` and not the `amount` field.