### PR TITLE
Update http-interfaces.txt

### DIFF
--- a/source/tools/http-interfaces.txt
+++ b/source/tools/http-interfaces.txt
@@ -13,6 +13,25 @@ HTTP Interface
 REST Interfaces
 ---------------
 
+RESTHeart (Java)
+~~~~~~~~~~~~~~~~
+
+`RESTHeart <http://www.restheart.org>`_ Java REST API server for MongoDB, built on top of `Undertow <http://undertow.io>`_ non-blocking HTTP server.
+License: GNU AFFERO GENERAL PUBLIC LICENSE Version 3.
+
+- CRUD operations API on your data;
+- Data model operations API: create databases, collections, indexes and the data structure;
+- Super easy setup with convention over configuration approach;
+- Pluggable security with User Management and ACL;
+- `HAL <http://en.wikipedia.org/wiki/Hypertext_Application_Language>`_ hypermedia type;
+- Super lightweight: pipeline architecture, ~6Mb footprint, ~200Mb RAM peek usage, starts in milliseconds;
+- High throughput: very small overhead on MongoDB performance;
+- Horizontally scalable: fully stateless architecture supporting MongoDB replica sets and shards;
+- Built on top of `Undertow <http://undertow.io>`_ non-blocking HTTP server;
+- Embeds the excellent `HAL browser <https://github.com/mikekelly/hal-browser>`_ by Mike Kelly (the author of the HAL specifications);
+- Support `Cross-Origin Resource Sharing <http://www.w3.org/TR/cors/>`_ (CORS) so that your one page web application can deal with RESTHeart running on a different domain. In other words, CORS is an evolution of `JSONP <http://en.wikipedia.org/wiki/JSONP>`_;
+- Ideal as AngularJS (or any other MVW Javascript framework) back-end.
+
 DrowsyDromedary (Ruby)
 ~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Added RESTHeart, Java REST API server for MongoDB. Based on Undertow HTTP non-blocking server. GNU AGPL V3 license.
