### PR TITLE
Update google-compute-engine.txt

### DIFF
--- a/source/platforms/google-compute-engine.txt
+++ b/source/platforms/google-compute-engine.txt
@@ -88,7 +88,7 @@ instance. The instance will be configured as follows:
 
 - MongoDB 2.4.x installed via Yum
 
-- Individual persistent disks for data, journal, and log
+- One persistent disk for MongoDB data, including journal and log
 
 - Updated read-ahead values for each disk
 


### PR DESCRIPTION
"Individual persistent disks" is the opposite of what this setup does. Corrected to "One persistent disk"