### PR TITLE
Update hadoop documentation

### DIFF
--- a/source/tools/hadoop.txt
+++ b/source/tools/hadoop.txt
@@ -29,28 +29,21 @@ This guide also includes the following documentation:
 Installation
 ------------
 
-The MongoDB Connector for Hadoop uses `Gradle
-<http://gradle.org>`_ tool for compilation. To build, simply invoke the ``jar`` task
-as seen with the following command:
+1. Obtain the Hadoop connector.
+You may either `download the JARs <https://github.com/mongodb/mongo-hadoop/releases>`__ 
+or `build it yourself <https://github.com/mongodb/mongo-hadoop/blob/master/README.md#building>`__.
+The JARs are universal and will work with any version of Hadoop.
 
-.. code-block:: sh
+2. Obtain a JAR for the `MongoDB Java Driver </drivers/java>`__.
 
-   ./gradlew jar
+3. Move these JARs onto each node of the Hadoop cluster.
+You may provision each node so that the jars are in the ``lib`` directory
+for hadoop (i.e. ``$HADOOP_HOME/lib``), or you can use the Hadoop
+`DistributedCache <http://hadoop.apache.org/docs/stable/api/org/apache/hadoop/filecache/DistributedCache.html>`__
+ to move the JARs onto pre-existing nodes.
 
-The MongoDB Connector for Hadoop supports a number of Hadoop releases. You
-can change the Hadoop version supported by passing the ``clusterVersion`` parameter to gradle.
-For instance, to build against Apache Hadoop 2.2 use the following command:
-
-.. code-block:: sh
-
-   ./gradlew jar -PclusterVersion=2.2
-
-After building, you will need to place the "core" jar and the
-``mongo-java-driver`` in the ``lib`` directory of each Hadoop server.
-
-For more complete install instructions please see the `install
-instructions in the readme
-<https://github.com/mongodb/mongo-hadoop/blob/master/README.md#building-the-adapter>`_
+For more complete install instructions please see the installation instructions
+for your platform on the `Hadoop Connector wiki <https://github.com/mongodb/mongo-hadoop/wiki>`__
 
 Presentations
 -------------

--- a/source/tools/hadoop.txt
+++ b/source/tools/hadoop.txt
@@ -48,8 +48,14 @@ for your platform on the `Hadoop Connector wiki <https://github.com/mongodb/mong
 Presentations
 -------------
 
+- `MongoDB and Hadoop: Driving Business Insights <http://www.mongodb.com/presentations/mongodb-and-hadoop-driving-business-insights>`_
+  by Sandeep Parikh, 2014
+
+- `Webinar: Using MongoDB + Hadoop Together <http://www.mongodb.com/presentations/webinar-using-hadoop-mongodb-together>`_
+  by Buzz Moschetti, 2014
+
 - `What's New With MongoDB Hadoop Integration <http://www.mongodb.com/presentations/webinar-whats-new-mongodb-hadoop-integration>`_
-   By Mike O'Brien
+  By Mike O'Brien
 
 - `MongoDB, Hadoop and HuMONGOus Data
   <http://www.mongodb.com/presentations/mongosf-2012/mongodb-and-hadoop>`_

--- a/source/tools/hadoop.txt
+++ b/source/tools/hadoop.txt
@@ -11,10 +11,10 @@ MongoDB Connector for Hadoop
 The MongoDB Connector for Hadoop is a plugin for Hadoop that provides
 the ability to use MongoDB as an input source and/or an output destination.
 
-The source code is available on `github
+The source code is available on `Github
 <https://github.com/mongodb/mongo-hadoop>`_ where you can find a more
-comprehensive `readme
-<https://github.com/mongodb/mongo-hadoop/blob/master/README.md>`_.
+comprehensive `wiki
+<https://github.com/mongodb/mongo-hadoop/wiki>`_.
 
 If you have questions please email the `mongodb-user Mailing List
 <http://groups.google.com/group/mongodb-user>`_. For any issues please
@@ -30,20 +30,18 @@ Installation
 ------------
 
 1. Obtain the Hadoop connector.
-You may either `download the JARs <https://github.com/mongodb/mongo-hadoop/releases>`__ 
-or `build it yourself <https://github.com/mongodb/mongo-hadoop/blob/master/README.md#building>`__.
-The JARs are universal and will work with any version of Hadoop.
-
-2. Obtain a JAR for the `MongoDB Java Driver </drivers/java>`__.
-
+   You may either `download the JARs <https://github.com/mongodb/mongo-hadoop/releases>`_
+   or `build it yourself <https://github.com/mongodb/mongo-hadoop/blob/master/README.md#building>`_.
+   The JARs are universal and will work with any version of Hadoop.
+2. Obtain a JAR for the `MongoDB Java Driver </drivers/java>`_.
 3. Move these JARs onto each node of the Hadoop cluster.
-You may provision each node so that the jars are in the ``lib`` directory
-for hadoop (i.e. ``$HADOOP_HOME/lib``), or you can use the Hadoop
-`DistributedCache <http://hadoop.apache.org/docs/stable/api/org/apache/hadoop/filecache/DistributedCache.html>`__
- to move the JARs onto pre-existing nodes.
+   You may provision each node so that the jars are in the ``lib`` directory
+   for hadoop (i.e. ``$HADOOP_HOME/lib``), or you can use the Hadoop
+   `DistributedCache <http://hadoop.apache.org/docs/stable/api/org/apache/hadoop/filecache/DistributedCache.html>`_
+   to move the JARs onto pre-existing nodes.
 
-For more complete install instructions please see the installation instructions
-for your platform on the `Hadoop Connector wiki <https://github.com/mongodb/mongo-hadoop/wiki>`__
+For more complete install instructions, please see the installation instructions
+for your platform on the `Hadoop Connector wiki <https://github.com/mongodb/mongo-hadoop/wiki#using-the-connector>`_.
 
 Presentations
 -------------

--- a/source/tutorial/getting-started-with-hadoop.txt
+++ b/source/tutorial/getting-started-with-hadoop.txt
@@ -107,43 +107,12 @@ Miscellaneous
 In addition to Hadoop, you should also have ``git``, ``python``, and JDK 1.6
 installed.
 
-Building MongoDB Connector for Hadoop
--------------------------------------
+Getting the Hadoop Connector
+----------------------------
 
-The MongoDB Connector for Hadoop source is available on github. First, clone
-the repository.  If you want build a specific version you can check out the tag
-for that version.  For example, to build the 1.2.0 version, get the ``r1.2.0`` tag:
-
-.. code-block:: sh
-
-   git clone https://github.com/mongodb/mongo-hadoop.git
-   git checkout r1.2.0
-
-The hadoop connector use `gradle <http://gradle.org>`_ to build.  By default, the connector
-will build with the latest Apache Hadoop release (currently 2.4).  If you need to build for a 
-different version, simply pass ``-PclusterVersion=<your version>`` when building.  For example,
-to build against the CDH 4 distribution libraries, you would run this command:
-
-.. code-block:: sh
-
-   ./gradlew jar -PclusterVersion=cdh4
-
-For a list of all the support distributions and what setting to use to build for each one, check the
-listing in the detailed documentation on mongo-hadoop versions 
-`here <https://github.com/mongodb/mongo-hadoop/blob/master/README.md#supported-distributions-of-hadoop>`_
-
-Once the connector is built, you will need to copy it and the latest
-stable version of the `MongoDB Java driver`_ to your
-``$HADOOP_HOME/lib`` directory. For example, if you have Hadoop
-installed in ``/usr/lib/hadoop``:
-
-.. code-block:: sh
-
-   wget --no-check-certificate https://github.com/mongodb/mongo-java-driver/releases/download/r2.12.3/mongo-java-driver-2.12.3.jar
-   cp mongo-java-driver-2.12.3.jar /usr/lib/hadoop/lib/
-   cp core/build/libs/mongo-hadoop-core-1.3.0.jar /usr/lib/hadoop/lib/
-
-.. _`MongoDB Java driver`: https://github.com/mongodb/mongo-java-driver/releases
+The MongoDB Connector for Hadoop source code and pre-built JARs are all available
+on its `Github page <https://github.com/mongodb/mongo-hadoop>`_ along with specific
+installation instructions in the `wiki <https://github.com/mongodb/mongo-hadoop/wiki#using-the-connector>`_.
 
 Examples
 --------
@@ -186,7 +155,7 @@ Where to go from here
 ~~~~~~~~~~~~~~~~~~~~~
 
 Read the full documentation on the MongoDB Connector for Hadoop 
-`here <https://github.com/mongodb/mongo-hadoop/blob/master/README.md#supported-distributions-of-hadoop>`_.
+`here <https://github.com/mongodb/mongo-hadoop/wiki>`_.
 To modify configuration options, you can put additional lines in the ``historicalYield`` task to set
 properties passed to hadoop at runtime. Read the full comments of the script to see details on
 using these options to read/write from BSON as well as mongoDB collections.


### PR DESCRIPTION
Changes:

- Give updated, basic installation instructions for the Hadoop connector, deferring to the wiki for more thorough documentation.
- Add a couple more recent presentations to Hadoop page.
- Fix a formatting error with one of the presentation links.
