### PR TITLE
Add missing Java class for example below

### DIFF
--- a/source/tutorial/getting-started-with-java-driver.txt
+++ b/source/tutorial/getting-started-with-java-driver.txt
@@ -52,6 +52,7 @@ database ``mydb`` on the local machine :
    import com.mongodb.DBObject;
    import com.mongodb.MongoClient;
    import com.mongodb.ParallelScanOptions;
+   import com.mongodb.ServerAddress;
 
    import java.util.List;
    import java.util.Set;


### PR DESCRIPTION
Note. There are some extra classes that are needed for examples underneath, but not all the classes are added. For example `BasicDBObject`