### PR TITLE
Fix typo in MongoCredential and correct how to specify SSL in Java Driver < 3.0

### DIFF
--- a/source/tutorial/authenticate-with-java-driver.txt
+++ b/source/tutorial/authenticate-with-java-driver.txt
@@ -54,9 +54,10 @@ This authentication method requires the use of SSL connections with certificate 
 
 .. code-block:: java
 
-   MongoCredential credential = MongoCredential.MongoCredential.createMongoX509Credential("<X.509 derived username>");
+   MongoCredential credential = MongoCredential.createMongoX509Credential("<X.509 derived username>");
 
-   MongoClient mongoClient = new MongoClient(new ServerAddress(server), Arrays.asList(credential), MongoClientOptions.builder().sslEnabled(true).build());
+   // using release 2.12 or later
+   mongoClient mongoClient = new MongoClient(new ServerAddress(server), Arrays.asList(credential), MongoClientOptions.builder().socketFactory(SSLSocketFactory.getDefault()).build());
 
 GSSAPI (Kerberos) Authentication
 --------------------------------


### PR DESCRIPTION
https://jira.mongodb.org/browse/JAVA-869

Moved 3.0 syntax to it's own tutorial (#248)