### PR TITLE
Add DigitalOcean to the Platforms section.

### DIFF
--- a/source/platforms.txt
+++ b/source/platforms.txt
@@ -11,6 +11,14 @@ Amazon Web Services EC2
    platforms/amazon-ec2
    tutorial/backup-and-restore-mongodb-on-amazon-ec2
 
+DigitalOcean
+---------------
+
+.. toctree::
+   :maxdepth: 1
+
+   platforms/digitalocean
+
 dotCloud
 --------
 

--- a/source/platforms/digitalocean.txt
+++ b/source/platforms/digitalocean.txt
@@ -1,0 +1,89 @@
+.. _digitalocean:
+
+============
+DigitalOcean
+============
+
+.. default-domain:: mongodb
+
+Deploying a MongoDB instance on `DigitalOcean <https://www.digitalocean.com/>`_
+is simple with the MongoDB One-Click application. It allows you to spin up a
+server with MongoDB pre-installed so you can get your application off the
+ground quickly.
+
+Launching a MongoDB Instance
+----------------------------
+
+You can launch a new MongoDB instance by selecting **MongoDB** from the
+**Applications** tab on the Droplet create page:
+
+.. image:: /images/digitalocean-control-panel.png
+
+Once you have created your server, you can connect to it via the web-based
+console in the DigitalOcean control panel or via SSH:
+
+.. code-block:: sh
+
+    ssh root@your.ip.address
+
+Using the API
+~~~~~~~~~~~~~
+
+One-Click Application images are also available via `DigitalOcean's RESTful
+API <https://developers.digitalocean.com/documentation/v2/>`_. Use the slug
+(``"mongodb"``) rather than an ID when specifying the image to ensure you are
+using the most up to date version.
+
+The following example will launch a launch a 2 GB server with private networking
+enabled, running MongoDB in the NYC3 region. Of course, remember to replace the
+API access token with one of your own `obtained in the DigtialOcean control
+panel <https://www.digitalocean.com/community/tutorials/how-to-use-the-digitalocean-api-v2#how-to-generate-a-personal-access-token>`_.
+
+.. code-block:: sh
+
+    curl -X POST -H 'Content-Type: application/json' \
+        -H 'Authorization: Bearer b7d03a6947b217efb6f3ec3bd3504582' \
+        -d '{"name":"shard-01.example.com", "region":"nyc3","size":"2gb", "image":"mongodb", "private_networking":true}' \
+        "https://api.digitalocean.com/v2/droplets"
+
+Instance Details
+----------------
+
+The environment on your new server will consist of:
+
+* Ubuntu 14.04 LTS
+* MongoDB 3.x installed via Apt from the upstream repository
+
+MongoDB will be available at port 27017 and is bound to the localhost by
+default. Its data is stored in :file:`/var/lib/mongodb/`. You can view or
+modify its configuration details in :file:`/etc/mongod.conf`.
+
+To connect to the test database with the MongoDB shell, simply run:
+
+.. code-block:: sh
+
+    mongo
+
+The daemon will be running by default and can be managed using the native
+service commands, i.e.:
+
+.. code-block:: sh
+
+   sudo service mongodb restart
+
+Additional Information
+----------------------
+
+The One-Click application simply provides you with MongoDB as a pre-installed
+base. It's up to you how you want to use it. Whether you are building out a
+sharded cluster or simply want to connect it to an app on the same host, the
+DigitalOcean community has a number of tutorials which should point you in the
+right direction:
+
+* `How To Implement Replication Sets in MongoDB <https://www.digitalocean.com/community/tutorials/how-to-implement-replication-sets-in-mongodb-on-an-ubuntu-vps>`_
+* `How To Create a Sharded Cluster in MongoDB <https://www.digitalocean.com/community/tutorials/how-to-create-a-sharded-cluster-in-mongodb-using-an-ubuntu-12-04-vps>`_
+* `How To Connect Node.js to a MongoDB Database <https://www.digitalocean.com/community/tutorials/how-to-connect-node-js-to-a-mongodb-database-on-a-vps>`_
+
+A `MEAN Stack One-Click application image <https://www.digitalocean.com/community/tutorials/how-to-use-the-mean-one-click-install-image>`_
+is also available. It provides Node.js, Express, and AngularJS pre-installed
+along side of MongoDB.


### PR DESCRIPTION
This adds details on using MongoDB on DigitalOcean to the Platforms section of the documentation. I kept it simple as going into details about how to use MongoDB itself (as some of the other providers covered do) seems a bit redundant. Let me know if the voice is ok, the different providers seem to vary in tone.

I'll open a corresponding PR against https://github.com/mongodb/docs-assets/tree/ecosystem for the image.

![digitalocean-control-panel](https://cloud.githubusercontent.com/assets/46943/6514676/4170cfc8-c352-11e4-80e2-9c879837e8e0.png)

Thanks!