### PR TITLE
DOCS-5004: updates compatibility tables with new nomenclature

### DIFF
--- a/source/drivers/c.txt
+++ b/source/drivers/c.txt
@@ -56,34 +56,34 @@ MongoDB Compatibility
      - 3.0
    * -
      - ``0.90.0``
-     - Compatible
-     - Compatible
-     - Unknown
+     - Supported
+     - Supported
+     - Unsupported
    * -
      - ``0.92.0``
-     - Compatible
-     - Compatible
-     - Unknown
+     - Supported
+     - Supported
+     - Unsupported
    * -
      - ``0.92.2``
-     - Compatible
-     - Compatible
-     - Unknown
+     - Supported
+     - Supported
+     - Unsupported
    * -
      - ``0.92.3 (git)``
-     - Compatible
-     - Compatible
-     - Unknown
+     - Supported
+     - Supported
+     - Unsupported
    * - 
      - ``1.0.0``
-     - Compatible
-     - Compatible
-     - Compatible
+     - Supported
+     - Supported
+     - Supported
    * - Driver Version
      - ``1.1.0``
-     - Compatible
-     - Compatible
-     - Compatible
+     - Supported
+     - Supported
+     - Supported
 
 .. include:: /includes/older-server-versions-unsupported.rst
 
@@ -106,6 +106,6 @@ Language Compatibility
      - C11
    * - Driver Version
      - all versions
-     - Compatible
-     - Compatible
-     - Compatible
+     - Supported
+     - Supported
+     - Supported

--- a/source/drivers/cpp.txt
+++ b/source/drivers/cpp.txt
@@ -35,14 +35,14 @@ MongoDB Compatibility
      - 3.0
    * -
      - ``legacy-0.0-26compat-2.6.4``
-     - Untested
-     - Compatible
-     - Compatible
+     - Minor incompatibility
+     - Supported
+     - Supported
    * - Driver Version
      - ``legacy-1.0.0``
-     - Compatible
-     - Compatible
-     - Compatible
+     - Supported
+     - Supported
+     - Supported
 
 .. include:: /includes/older-server-versions-unsupported.rst
 
@@ -65,11 +65,11 @@ Language Compatibility
      - C++14
    * -
      - ``legacy-0.0-26compat-2.6.4``
-     - Compatible
-     - Compatible
-     - Compatible
+     - Supported
+     - Supported
+     - Supported
    * - Driver Version
      - ``legacy-1.0.0``
-     - Compatible
-     - Compatible
-     - Compatible
+     - Supported
+     - Supported
+     - Supported

--- a/source/drivers/csharp.txt
+++ b/source/drivers/csharp.txt
@@ -89,34 +89,34 @@ MongoDB Compatibility
      - 3.0
    * -
      - ``< 1.6``
-     - Untested
-     - Untested
-     - Untested   
+     - Minor incompatibility
+     - Minor incompatibility
+     - Minor incompatibility   
    * -
      - ``1.7-1.7.1``
-     - Untested
-     - Untested
-     - Untested
+     - Minor incompatibility
+     - Minor incompatibility
+     - Minor incompatibility
    * -
      - ``1.8-1.8.3``
-     - Compatible
-     - Untested
-     - Untested
+     - Supported
+     - Minor incompatibility
+     - Minor incompatibility
    * -
      - ``1.9-1.9.2``
-     - Compatible
-     - Compatible
-     - Untested
+     - Supported
+     - Supported
+     - Minor incompatibility
    * -
      - ``1.10``
-     - Compatible
-     - Compatible
-     - Compatible
+     - Supported
+     - Supported
+     - Supported
    * - Driver Version
      - ``2.0``
-     - Compatible
-     - Compatible
-     - Compatible
+     - Supported
+     - Supported
+     - Supported
 
 .. include:: /includes/older-server-versions-unsupported.rst
 
@@ -147,31 +147,31 @@ MongoDB Compatibility
     - Mono 3.x
   * -
     - ``<= 1.9.2``
-    - Incompatible
-    - Incompatible
-    - Compatible
-    - Compatible
-    - Compatible
-    - Compatible
-    - Untested
+    - Unsupported
+    - Unsupported
+    - Supported
+    - Supported
+    - Supported
+    - Supported
+    - Minor incompatibility
   * -
     - ``1.10``
-    - Incompatible
-    - Incompatible
-    - Compatible
-    - Compatible
-    - Compatible
-    - Compatible
-    - Compatible
+    - Unsupported
+    - Unsupported
+    - Supported
+    - Supported
+    - Supported
+    - Supported
+    - Supported
   * - Driver Verion
     - ``2.0``
-    - Incompatible
-    - Incompatible
-    - Incompatible
-    - Incompatible
-    - Compatible
-    - Compatible
-    - Compatible
+    - Unsupported
+    - Unsupported
+    - Unsupported
+    - Unsupported
+    - Supported
+    - Supported
+    - Supported
 
 Visual Studio Support
 ~~~~~~~~~~~~~~~~~~~~~

--- a/source/drivers/go.txt
+++ b/source/drivers/go.txt
@@ -31,9 +31,9 @@ MongoDB Compatibility
      - 3.0
    * - Driver Version
      - ``v2``
-     - Compatible
-     - Compatible
-     - Compatible
+     - Supported
+     - Supported
+     - Supported
 
 .. include:: /includes/older-server-versions-unsupported.rst
 
@@ -58,10 +58,10 @@ Language Compatibility
      - go1.4
    * - Driver Version
      - ``v2``
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
+     - Supported
+     - Supported
+     - Supported
+     - Supported
 
 Resources
 ---------

--- a/source/drivers/java.txt
+++ b/source/drivers/java.txt
@@ -60,34 +60,34 @@ MongoDB Compatibility
      - 3.0
    * -
      - ``2.9``
-     - Untested
-     - Untested
-     - Untested
+     - Minor incompatibility
+     - Minor incompatibility
+     - Minor incompatibility
    * -
      - ``2.10``
-     - Untested
-     - Untested
-     - Untested
+     - Minor incompatibility
+     - Minor incompatibility
+     - Minor incompatibility
    * -
      - ``2.11``
-     - Compatible
-     - Untested
-     - Untested
+     - Supported
+     - Minor incompatibility
+     - Minor incompatibility
    * -
      - ``2.12``
-     - Compatible
-     - Compatible
-     - Untested
+     - Supported
+     - Supported
+     - Minor incompatibility
    * -
      - ``2.13``
-     - Compatible
-     - Compatible
-     - Compatible
+     - Supported
+     - Supported
+     - Supported
    * - Driver Version
      - ``3.0``
-     - Compatible
-     - Compatible
-     - Compatible
+     - Supported
+     - Supported
+     - Supported
 
 .. include:: /includes/older-server-versions-unsupported.rst
 
@@ -112,52 +112,52 @@ Language Compatibility
     - Java 8
   * -
     - ``2.7``
-    - Compatible
-    - Compatible
-    - Compatible
-    - Compatible
+    - Supported
+    - Supported
+    - Supported
+    - Supported
   * -
     - ``2.8``
-    - Compatible
-    - Compatible
-    - Compatible
-    - Compatible
+    - Supported
+    - Supported
+    - Supported
+    - Supported
   * -
     - ``2.9``
-    - Compatible
-    - Compatible
-    - Compatible
-    - Compatible
+    - Supported
+    - Supported
+    - Supported
+    - Supported
   * -
     - ``2.10``
-    - Compatible
-    - Compatible
-    - Compatible
-    - Compatible
+    - Supported
+    - Supported
+    - Supported
+    - Supported
   * -
     - ``2.11``
-    - Compatible
-    - Compatible
-    - Compatible
-    - Compatible
+    - Supported
+    - Supported
+    - Supported
+    - Supported
   * -
     - ``2.12``
-    - Compatible
-    - Compatible
-    - Compatible
-    - Compatible
+    - Supported
+    - Supported
+    - Supported
+    - Supported
   * -
     - ``2.13``
-    - Compatible
-    - Compatible
-    - Compatible
-    - Compatible
+    - Supported
+    - Supported
+    - Supported
+    - Supported
   * - Driver Version
     - ``3.0``
-    - Incompatible
-    - Compatible
-    - Compatible
-    - Compatible
+    - Unsupported
+    - Supported
+    - Supported
+    - Supported
 
 Third Party Frameworks and Libraries
 ------------------------------------

--- a/source/drivers/node-js.txt
+++ b/source/drivers/node-js.txt
@@ -65,29 +65,29 @@ MongoDB Compatibility
      - 3.0
    * -
      - ``1.2.X``
-     - Compatible
-     - Untested
-     - Untested
+     - Supported
+     - Minor incompatibility
+     - Minor incompatibility
    * -
      - ``1.3.X``
-     - Compatible
-     - Untested
-     - Untested
+     - Supported
+     - Minor incompatibility
+     - Minor incompatibility
    * -
      - ``1.4.X``
-     - Compatible
-     - Compatible
-     - Untested
+     - Supported
+     - Supported
+     - Minor incompatibility
    * -
      - ``>=1.4.29``
-     - Compatible
-     - Compatible
-     - Compatible
+     - Supported
+     - Supported
+     - Supported
    * - Driver Version
      - ``>=2.0.14``
-     - Compatible
-     - Compatible
-     - Compatible
+     - Supported
+     - Supported
+     - Supported
 
 Language Compatibility
 ``````````````````````
@@ -108,29 +108,29 @@ Language Compatibility
      - v0.11.X unstable
    * -
      - ``1.2.X``
-     - Compatible
-     - Compatible
-     - Untested
+     - Supported
+     - Supported
+     - Minor incompatibility
    * -
      - ``1.3.X``
-     - Compatible
-     - Compatible
-     - Untested
+     - Supported
+     - Supported
+     - Minor incompatibility
    * -
      - ``1.4.X``
-     - Compatible
-     - Compatible
-     - Untested
+     - Supported
+     - Supported
+     - Minor incompatibility
    * -
      - ``>=1.4.18``
-     - Compatible
-     - Compatible
-     - Compatible
+     - Supported
+     - Supported
+     - Supported
    * - Driver Version
      - ``2.0.X``
-     - Compatible
-     - Compatible
-     - Compatible
+     - Supported
+     - Supported
+     - Supported
 
 Object Mappers
 --------------

--- a/source/drivers/perl.txt
+++ b/source/drivers/perl.txt
@@ -43,56 +43,56 @@ MongoDB Compatibility
      - 3.0
    * -
      - ``0.470.x``
-     - Incompatible
-     - Incompatible
-     - Incompatible
+     - Minor incompatibility
+     - Minor incompatibility
+     - Minor incompatibility
    * -
      - ``0.503.x``
-     - Incompatible
-     - Incompatible
-     - Incompatible
+     - Minor incompatibility
+     - Minor incompatibility
+     - Minor incompatibility
    * -
      - ``0.701.x``
-     - Untested
-     - Incompatible
-     - Incompatible
+     - Supported
+     - Minor incompatibility
+     - Minor incompatibility
    * -
      - ``0.702.x``
-     - Compatible
-     - Incompatible
-     - Incompatible
+     - Supported
+     - Minor incompatibility
+     - Minor incompatibility
    * -
      - ``0.704.x``
-     - Compatible
-     - Untested
-     - Untested
+     - Supported
+     - Minor incompatibility
+     - Minor incompatibility
    * -
      - ``0.705.x``
-     - Compatible
-     - Untested
-     - Untested
+     - Supported
+     - Minor incompatibility
+     - Minor incompatibility
    * -
      - ``0.706.x``
-     - Compatible
-     - Untested
-     - Untested
+     - Supported
+     - Minor incompatibility
+     - Minor incompatibility
    * -
      - ``0.707.x``
-     - Compatible
-     - Untested
-     - Untested
+     - Supported
+     - Minor incompatibility
+     - Minor incompatibility
    * - Driver Version
      - ``0.708.x``
-     - Compatible
-     - Untested
-     - Untested
+     - Supported
+     - Minor incompatibility
+     - Minor incompatibility
 
 .. TODO: add in 1.0.0.0 once the driver releases
 .. * - Driver Version
 ..   - ``1.0.0.0``
-..   - Compatible
-..   - Compatible
-..   - Compatible
+..   - Supported
+..   - Supported
+..   - Supported
 
 .. include:: /includes/older-server-versions-unsupported.rst
 
@@ -125,76 +125,76 @@ Language Compatibility
      - 5.20
    * -
      - ``0.470.x``
-     - Untested
-     - Untested
-     - Untested
-     - Untested
-     - Untested
-     - Untested
-     - Untested
-     - Untested
+     - Minor incompatibility
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Supported
    * -
      - ``0.503.x``
-     - Untested
-     - Untested
-     - Untested
-     - Untested
-     - Untested
-     - Untested
-     - Untested
-     - Untested
+     - Minor incompatibility
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Supported
    * -
      - ``0.701.x``
-     - Untested
-     - Untested
-     - Untested
-     - Untested
-     - Untested
-     - Untested
-     - Untested
-     - Untested
+     - Minor incompatibility
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Supported
    * -
      - ``0.702.x``
-     - Untested
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
+     - Minor incompatibility
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Supported
    * -
      - ``0.704.x``
-     - Untested
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
+     - Minor incompatibility
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Supported
    * - Driver Version
      - ``0.705.x``
-     - Untested
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
+     - Minor incompatibility
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Supported
 
 .. TODO: add in 1.0.0.0 once the driver releases
 .. * - Driver Version
 ..   - ``1.0.0.0``
-..   - Untested
-..   - Compatible
-..   - Compatible
-..   - Compatible
-..   - Compatible
-..   - Compatible
-..   - Compatible
-..   - Compatible
+..   - Minor incompatibility
+..   - Supported
+..   - Supported
+..   - Supported
+..   - Supported
+..   - Supported
+..   - Supported
+..   - Supported
 
 Third-party Perl Drivers
 ------------------------

--- a/source/drivers/php.txt
+++ b/source/drivers/php.txt
@@ -100,34 +100,34 @@ MongoDB Compatibility
      - 3.0
    * -
      - ``1.2``
-     - Untested
-     - Untested
-     - Untested
+     - Minor incompatibility
+     - Minor incompatibility
+     - Minor incompatibility
    * -
      - ``1.3``
-     - Compatible
-     - Untested
-     - Untested
+     - Supported
+     - Minor incompatibility
+     - Minor incompatibility
    * -
      - ``1.4``
-     - Compatible
-     - Compatible
-     - Untested
+     - Supported
+     - Supported
+     - Minor incompatibility
    * -
      - ``1.5``
-     - Compatible
-     - Compatible
-     - Untested
+     - Supported
+     - Supported
+     - Minor incompatibility
    * -
      - ``1.6``
-     - Compatible
-     - Compatible
-     - Compatible
+     - Supported
+     - Supported
+     - Supported
    * - Driver Version
      - ``phongo``
-     - Compatible
-     - Compatible
-     - Compatible
+     - Supported
+     - Supported
+     - Supported
 
 .. include:: /includes/older-server-versions-unsupported.rst
 
@@ -156,52 +156,52 @@ Language Compatibility
     - 7.0
   * -
     - ``1.2``
-    - Compatible
-    - Compatible
-    - Compatible
-    - Compatible
-    - Untested
-    - Incompatible
+    - Supported
+    - Supported
+    - Supported
+    - Supported
+    - Minor incompatibility
+    - Unsupported
   * -
     - ``1.3``
-    - Untested
-    - Compatible
-    - Compatible
-    - Compatible
-    - Untested
-    - Incompatible
+    - Minor incompatibility
+    - Supported
+    - Supported
+    - Supported
+    - Minor incompatibility
+    - Unsupported
   * -
     - ``1.4``
-    - Untested
-    - Compatible
-    - Compatible
-    - Compatible
-    - Untested
-    - Incompatible
+    - Minor incompatibility
+    - Supported
+    - Supported
+    - Supported
+    - Minor incompatibility
+    - Unsupported
   * -
     - ``1.5``
-    - Untested
-    - Compatible
-    - Compatible
-    - Compatible
-    - Compatible
-    - Incompatible
+    - Minor incompatibility
+    - Supported
+    - Supported
+    - Supported
+    - Supported
+    - Unsupported
   * -
     - ``1.6``
-    - Incompatible
-    - Compatible
-    - Compatible
-    - Compatible
-    - Compatible
-    - Incompatible
+    - Unsupported
+    - Supported
+    - Supported
+    - Supported
+    - Supported
+    - Unsupported
   * - Driver Version
     - ``phongo``
-    - Incompatible
-    - Untested
-    - Compatible
-    - Compatible
-    - Compatible
-    - Incompatible
+    - Unsupported
+    - Minor incompatibility
+    - Supported
+    - Supported
+    - Supported
+    - Unsupported
 
 See Also
 --------

--- a/source/drivers/python.txt
+++ b/source/drivers/python.txt
@@ -51,44 +51,44 @@ MongoDB Compatibility
      - 3.0
    * -
      - ``2.2``
-     - Incompatible
-     - Incompatible
-     - Incompatible
+     - Unsupported
+     - Unsupported
+     - Unsupported
    * -
      - ``2.3``
-     - Untested
-     - Untested
-     - Untested
+     - Minor incompatibility
+     - Minor incompatibility
+     - Minor incompatibility
    * -
      - ``2.4``
-     - Untested
-     - Untested
-     - Untested
+     - Minor incompatibility
+     - Minor incompatibility
+     - Minor incompatibility
    * -
      - ``2.5``
-     - Compatible
-     - Untested
-     - Untested
+     - Supported
+     - Minor incompatibility
+     - Minor incompatibility
    * -
      - ``2.6``
-     - Compatible
-     - Untested
-     - Untested
+     - Supported
+     - Minor incompatibility
+     - Minor incompatibility
    * -
      - ``2.7``
-     - Compatible
-     - Compatible
-     - Untested
+     - Supported
+     - Supported
+     - Minor incompatibility
    * -
      - ``2.8``
-     - Compatible
-     - Compatible
-     - Compatible
+     - Supported
+     - Supported
+     - Supported
    * - Driver Version
      - ``3.0``
-     - Compatible
-     - Compatible
-     - Compatible
+     - Supported
+     - Supported
+     - Supported
 
 .. include:: /includes/older-server-versions-unsupported.rst
 
@@ -123,92 +123,92 @@ Language Compatibility
      - 3.5
    * -
      - ``2.2``
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Untested
-     - Untested
-     - Untested
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Minor incompatibility
+     - Minor incompatibility
+     - Minor incompatibility
    * -
      - ``2.3``
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Untested
-     - Untested
-     - Untested
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Minor incompatibility
+     - Minor incompatibility
+     - Minor incompatibility
    * -
      - ``2.4``
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Untested
-     - Untested
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Minor incompatibility
+     - Minor incompatibility
    * -
      - ``2.5``
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Untested
-     - Untested
-     - Untested
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Minor incompatibility
+     - Minor incompatibility
+     - Minor incompatibility
    * -
      - ``2.6``
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Untested
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Minor incompatibility
    * -
      - ``2.7``
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Untested
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Minor incompatibility
    * -
      - ``2.8``
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Untested
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Minor incompatibility
    * - Driver Version
      - ``3.0``
-     - Incompatible
-     - Incompatible
-     - Compatible
-     - Compatible
-     - Incompatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Untested
+     - Unsupported
+     - Unsupported
+     - Supported
+     - Supported
+     - Unsupported
+     - Supported
+     - Supported
+     - Supported
+     - Minor incompatibility
 
 .. note:: 
    
@@ -263,24 +263,24 @@ MongoDB Compatibility
      - 3.0
    * - 
      - ``0.1`` (wraps PyMongo 2.5.0)
-     - Compatible
-     - Untested
-     - Untested
+     - Supported
+     - Minor incompatibility
+     - Minor incompatibility
    * - 
      - ``0.2`` (wraps PyMongo 2.7.0)
-     - Compatible
-     - Compatible
-     - Untested
+     - Supported
+     - Supported
+     - Minor incompatibility
    * - 
      - ``0.3`` (wraps PyMongo 2.7.1)
-     - Compatible
-     - Compatible
-     - Untested
+     - Supported
+     - Supported
+     - Minor incompatibility
    * - Driver Version
      - ``0.4`` (wraps PyMongo 2.8)
-     - Compatible
-     - Compatible
-     - Compatible
+     - Supported
+     - Supported
+     - Supported
 
 .. include:: /includes/older-server-versions-unsupported.rst
 
@@ -313,44 +313,44 @@ Language Compatibility
      - 3.5
    * -
      - ``0.1`` (wraps PyMongo 2.5.0)
-     - Compatible
-     - Compatible
-     - Compatible
-     - Untested
-     - Untested
-     - Compatible
-     - Untested
-     - Untested
+     - Supported
+     - Supported
+     - Supported
+     - Minor incompatibility
+     - Minor incompatibility
+     - Supported
+     - Minor incompatibility
+     - Minor incompatibility
    * -
      - ``0.2`` (wraps PyMongo 2.7.0)
-     - Incompatible
-     - Compatible
-     - Compatible
-     - Untested
-     - Untested
-     - Compatible
-     - Untested
-     - Untested
+     - Unsupported
+     - Supported
+     - Supported
+     - Minor incompatibility
+     - Minor incompatibility
+     - Supported
+     - Minor incompatibility
+     - Minor incompatibility
    * -
      - ``0.3`` (wraps PyMongo 2.7.1)
-     - Incompatible
-     - Compatible
-     - Compatible
-     - Untested
-     - Untested
-     - Compatible
-     - Compatible
-     - Untested
+     - Unsupported
+     - Supported
+     - Supported
+     - Minor incompatibility
+     - Minor incompatibility
+     - Supported
+     - Supported
+     - Minor incompatibility
    * - Driver Version
      - ``0.4``
-     - Incompatible
-     - Compatible
-     - Compatible
-     - Untested
-     - Untested
-     - Compatible
-     - Compatible
-     - Untested
+     - Unsupported
+     - Supported
+     - Supported
+     - Minor incompatibility
+     - Minor incompatibility
+     - Supported
+     - Supported
+     - Minor incompatibility
 
 .. note:: 
    

--- a/source/drivers/ruby.txt
+++ b/source/drivers/ruby.txt
@@ -99,44 +99,44 @@ MongoDB Compatibility
      - 3.0
    * -
      - ``1.6``
-     - Incompatible
-     - Incompatible
-     - Incompatible
+     - Unsupported
+     - Unsupported
+     - Unsupported
    * -
      - ``1.7``
-     - Incompatible
-     - Incompatible
-     - Incompatible
+     - Unsupported
+     - Unsupported
+     - Unsupported
    * -
      - ``1.8``
-     - Compatible
-     - Untested
-     - Untested
+     - Supported
+     - Minor incompatibility
+     - Minor incompatibility
    * -
      - ``1.9``
-     - Compatible
-     - Untested
-     - Untested
+     - Supported
+     - Minor incompatibility
+     - Minor incompatibility
    * -
      - ``1.10``
-     - Compatible
-     - Compatible
-     - Untested
+     - Supported
+     - Supported
+     - Minor incompatibility
    * -
      - ``1.11``
-     - Compatible
-     - Compatible
-     - Untested
+     - Supported
+     - Supported
+     - Minor incompatibility
    * -
      - ``1.12``
-     - Compatible
-     - Compatible
-     - Compatible
+     - Supported
+     - Supported
+     - Supported
    * - Driver Version
      - ``2.0``
-     - Compatible
-     - Compatible
-     - Compatible
+     - Supported
+     - Supported
+     - Supported
      
 Language Compatibility
 ``````````````````````
@@ -163,68 +163,68 @@ Language Compatibility
      - Rubinius
    * -
      - ``1.6``
-     - Compatible
-     - Compatible
-     - Untested
-     - Untested
-     - Compatible
-     - Untested
+     - Supported
+     - Supported
+     - Minor incompatibility
+     - Minor incompatibility
+     - Supported
+     - Minor incompatibility
    * -
      - ``1.7``
-     - Compatible
-     - Compatible
-     - Untested
-     - Untested
-     - Compatible
-     - Untested
+     - Supported
+     - Supported
+     - Minor incompatibility
+     - Minor incompatibility
+     - Supported
+     - Minor incompatibility
    * -
      - ``1.8``
-     - Compatible
-     - Compatible
-     - Compatible
-     - Untested
-     - Compatible
-     - Untested
+     - Supported
+     - Supported
+     - Supported
+     - Minor incompatibility
+     - Supported
+     - Minor incompatibility
    * -
      - ``1.9``
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Untested
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Minor incompatibility
    * -
      - ``1.10``
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Untested
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Minor incompatibility
    * -
      - ``1.11``
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Untested
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Minor incompatibility
    * -
      - ``1.12``
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Untested
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Minor incompatibility
    * - Driver Version
      - ``2.0``
-     - Incompatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Compatible
-     - Untested
+     - Unsupported
+     - Supported
+     - Supported
+     - Supported
+     - Supported
+     - Minor incompatibility
 
 BSON
 ~~~~

--- a/source/drivers/scala.txt
+++ b/source/drivers/scala.txt
@@ -44,34 +44,34 @@ MongoDB Compatibility
      - 3.0
    * -
      - ``2.4``
-     - Untested
-     - Untested
-     - Untested
+     - Minor incompatibility
+     - Minor incompatibility
+     - Minor incompatibility
    * -
      - ``2.5``
-     - Untested
-     - Untested
-     - Untested
+     - Minor incompatibility
+     - Minor incompatibility
+     - Minor incompatibility
    * -
      - ``2.6``
-     - Compatible
-     - Untested
-     - Untested
+     - Supported
+     - Minor incompatibility
+     - Minor incompatibility
    * -
      - ``2.7``
-     - Compatible
-     - Compatible
-     - Untested
+     - Supported
+     - Supported
+     - Minor incompatibility
    * -
      - ``2.8``
-     - Compatible
-     - Compatible
-     - Compatible
+     - Supported
+     - Supported
+     - Supported
    * - Driver Version
      - ``3.0``
-     - Compatible
-     - Compatible
-     - Compatible
+     - Supported
+     - Supported
+     - Supported
 
 .. include:: /includes/older-server-versions-unsupported.rst
 
@@ -96,40 +96,40 @@ Language Compatibility
     - Scala 2.11
   * -
     - ``2.4``
-    - Compatible
-    - Compatible
-    - Incompatible
-    - Incompatible
+    - Supported
+    - Supported
+    - Unsupported
+    - Unsupported
   * -
     - ``2.5``
-    - Incompatible
-    - Compatible
-    - Compatible
-    - Incompatible
+    - Unsupported
+    - Supported
+    - Supported
+    - Unsupported
   * -
     - ``2.6``
-    - Incompatible
-    - Compatible
-    - Compatible
-    - Incompatible
+    - Unsupported
+    - Supported
+    - Supported
+    - Unsupported
   * -
     - ``2.7``
-    - Incompatible
-    - Compatible
-    - Compatible
-    - Compatible
+    - Unsupported
+    - Supported
+    - Supported
+    - Supported
   * -
     - ``2.8``
-    - Incompatible
-    - Incompatible
-    - Compatible
-    - Compatible
+    - Unsupported
+    - Unsupported
+    - Supported
+    - Supported
   * - Driver Version
     - ``3.0``
-    - Incompatible
-    - Incompatible
-    - Incompatible
-    - Compatible
+    - Unsupported
+    - Unsupported
+    - Unsupported
+    - Supported
 
 Community
 ---------

--- a/source/includes/compatibility-legend.rst
+++ b/source/includes/compatibility-legend.rst
@@ -1,11 +1,9 @@
 .. list-table::
    :class: compatibility
    
-   * - compatible:
-     - Compatible
-   * - untested:
-     - Untested
-   * - incompatible:
-     - Incompatible
-   * - unknown:
-     - Unknown
+   * - supported. compatible. anything incompatible will be fixed:
+     - Supported
+   * - unsupported. minor incompatibilities may exist:
+     - Minor incompatibility
+   * - unsupported. incompatible:
+     - Unsupported


### PR DESCRIPTION
Compatible -> Supported
Untested -> Minor incompatibility
Incompatible -> Unsupported

Goes hand and hand with https://github.com/mongodb/docs-tools/pull/77