### PR TITLE
Remove eval from syntax table

### DIFF
--- a/source/includes/table-driver-syntax.yaml
+++ b/source/includes/table-driver-syntax.yaml
@@ -9,7 +9,6 @@ rows:
   - 5: [ content.code51, content.code52, content.code53, content.code54, content.code55, content.code56, content.code57, content.code58 ]
   - 6: [ content.code61, content.code62, content.code63, content.code64, content.code65, content.code66, content.code67, content.code68 ]
   - 7: [ content.code71, content.code72, content.code73, content.code74, content.code75, content.code76, content.code77, content.code78 ]
-  - 8: [ content.code81, content.code82, content.code83, content.code84, content.code85, content.code86, content.code87, content.code88 ]
 ---
 # table metadata, as meta.<key>
 section: meta
@@ -251,36 +250,4 @@ code78: |
          .. code-block:: perl 
 
             $collection->find_one()
-code81: |
-         .. code-block:: javascript
-
-            db.eval()
-code82: |
-         .. code-block:: python 
-
-            db.eval()
-code83: |
-         .. code-block:: php 
-
-            $db->execute()
-code84: |
-         .. code-block:: ruby
-
-            db.eval("return sum(2,3);")
-code85: |
-         .. code-block:: java 
-
-            db.doEval()
-code86: |
-         .. code-block:: cpp 
-
-            connection.eval()
-code87: |
-         .. code-block:: csharp 
-
-            db.Eval(js)
-code88: |
-         .. code-block:: perl 
-
-            $db->eval()
 ...


### PR DESCRIPTION
It isn't one of the most important functions, nor is it recommend to use at all