### PR TITLE
RUBY-874: Fix deletion docs for Ruby driver

### DIFF
--- a/source/tutorial/ruby-driver-tutorial.txt
+++ b/source/tutorial/ruby-driver-tutorial.txt
@@ -474,11 +474,11 @@ Removing documents from a collection is done either in single or multiples.
   client = Mongo::Client.new([ '127.0.0.1:27017' ], :database => 'music')
   artists = client[:artists]
 
-  result = artists.find(:name => 'Björk').remove_one
+  result = artists.find(:name => 'Björk').delete_one
   result.n #=> Returns 1.
 
-  result = artists.find(:label => 'Mute').remove_many
-  result.n #=> Returns the number removed.
+  result = artists.find(:label => 'Mute').delete_many
+  result.n #=> Returns the number deleted.
 
 Collections
 -----------


### PR DESCRIPTION
Docs were wrong on the names of the delete methods in the Ruby driver.