### PR TITLE
Mongo Ruby Driver versions > 1.10 do not support ensureIndex

### DIFF
--- a/source/drivers/ruby.txt
+++ b/source/drivers/ruby.txt
@@ -78,22 +78,22 @@ MongoDB Compatibility
      - Minor incompatibility
    * -
      - ``1.10``
-     - Supported
+     - Minor incompatibility
      - Supported
      - Minor incompatibility
    * -
      - ``1.11``
-     - Supported
+     - Minor incompatibility
      - Supported
      - Minor incompatibility
    * -
      - ``1.12``
-     - Supported
+     - Minor incompatibility
      - Supported
      - Supported
    * - Driver Version
      - ``2.0``
-     - Supported
+     - Minor incompatibility
      - Supported
      - Supported
      


### PR DESCRIPTION
Mongo 2.6 introduced `createIndexes`, whereas prior versions used `ensureIndex`.  With the advent of the ruby driver 1.10, support for `ensureIndex` was dropped.