### PR TITLE
Fix broken Nodejs link

### DIFF
--- a/source/drivers/node-js.txt
+++ b/source/drivers/node-js.txt
@@ -167,7 +167,7 @@ A few 3rd party drivers exist. While not officially supported, these
 drivers take a different approach that may be valuable given your
 needs.
 
-- `node-mongodb <https://github.com/orlandov/node-mongodb>_`: An
+- `node-mongodb <https://github.com/orlandov/node-mongodb>`_: An
   asynchronous Node interface to MongoDB, written in C.
 
 - `Mongolian DeadBeef <https://github.com/marcello3d/node-mongolian>`_:


### PR DESCRIPTION
Fixes the link to https://github.com/orlandov/node-mongodb