### PR TITLE
Include Camo project in node-js.txt

### DIFF
--- a/source/drivers/node-js.txt
+++ b/source/drivers/node-js.txt
@@ -149,6 +149,8 @@ Other Notable Projects
 
 - `MongoSmash <http://github.com/bengl/mongosmash>`_: Uses Harmony's ``Object.observe()``.
 
+- `Camo <https://github.com/scottwrobinson/camo>`_: A class-based ES6 ODM for MongoDB.
+
 Each of these projects build on top of the native Node.js driver, and so
 some knowledge of that is useful, especially if you work with a custom
 MongoDB configuration.


### PR DESCRIPTION
I created a class-based ES6 ODM for Mongo called [Camo](https://github.com/scottwrobinson/camo). I think it's a good alternative for ES6 users and for JavaScript novices thanks to its use of ES6 classes. [Here](http://stackabuse.com/introducing-camo-a-class-based-es6-odm-for-mongo-like-databases/) is a short article I wrote on its advantages and how to use it.