### PR TITLE
Fix Mongo Logger level configuration

### DIFF
--- a/source/tutorial/ruby-mongoid-tutorial.txt
+++ b/source/tutorial/ruby-mongoid-tutorial.txt
@@ -267,7 +267,7 @@ a different level. Logging level is ``DEBUG`` by default.
 .. code-block:: ruby
 
   Mongoid.logger.level = Logger::DEBUG
-  Mongo.logger.level = Logger::DEBUG
+  Mongo::Logger.logger.level = Logger::DEBUG
 
 
 Documents


### PR DESCRIPTION
According the spec_helper, the configuration is:

Mongo::Logger.logger.level = Logger::DEBUG