### PR TITLE
Fix Criteria#add_to_set parameter

### DIFF
--- a/source/tutorial/ruby-mongoid-tutorial.txt
+++ b/source/tutorial/ruby-mongoid-tutorial.txt
@@ -1792,7 +1792,7 @@ document inserts, updates, and deletion.
      -
         .. code-block:: ruby
 
-          Band.where(name: "Photek").add_to_set(:label, "Mute")
+          Band.where(name: "Photek").add_to_set(label: "Mute")
 
    * - ``Criteria#bit``
 


### PR DESCRIPTION
Passing two parameters to Criteria#add_to_set will result in a `ArgumentError: wrong number of arguments (2 for 1)` error.