### PR TITLE
Fixing #bit and #push_all parameters

### DIFF
--- a/source/tutorial/ruby-mongoid-tutorial.txt
+++ b/source/tutorial/ruby-mongoid-tutorial.txt
@@ -1801,7 +1801,7 @@ document inserts, updates, and deletion.
      -
         .. code-block:: ruby
 
-          Band.where(name: "Photek").bit(:likes, { and: 14, or: 4 })
+          Band.where(name: "Photek").bit(likes: { and: 14, or: 4 })
 
    * - ``Criteria#inc``
 
@@ -1858,7 +1858,7 @@ document inserts, updates, and deletion.
         .. code-block:: ruby
 
           Band.where(name: "Tool").
-            push_all(:members, [ "Maynard", "Danny" ])
+            push_all(members: [ "Maynard", "Danny" ])
 
    * - ``Criteria#rename``
 


### PR DESCRIPTION
Criteria#bit and Criteria#push_all expects a hash instead of multiple parameters