### PR TITLE
Update PHP links and compatibility tables

### DIFF
--- a/source/drivers/driver-compatibility-reference.txt
+++ b/source/drivers/driver-compatibility-reference.txt
@@ -481,22 +481,32 @@ MongoDB Compatibility
      - MongoDB 2.6
      - MongoDB 3.0
 
-   * - 1.6
+   * - mongodb-1.1
      - |checkmark|
      - |checkmark|
      - |checkmark|
 
-   * - 1.5
+   * - mongodb-1.0
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+
+   * - mongo-1.6
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+
+   * - mongo-1.5
      - |checkmark|
      - |checkmark|
      - 
 
-   * - 1.4
+   * - mongo-1.4
      - |checkmark|
      - |checkmark|
      - 
 
-   * - 1.3
+   * - mongo-1.3
      - |checkmark|
      - 
      - 
@@ -513,36 +523,62 @@ Language Compatibility
 .. list-table::
    :header-rows: 1
    :stub-columns: 1
-   :class: compatibility
+   :class: compatibility-large
 
    * - PHP Driver
      - PHP 5.3
      - PHP 5.4
      - PHP 5.5
      - PHP 5.6
+     - PHP 7.0
+     - HHVM 3.9
 
-   * - 1.6
+   * - mongodb-1.1
+     - 
      - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-
-   * - 1.5
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
 
-   * - 1.4
+   * - mongodb-1.0
+     - 
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - 
+     - |checkmark|
 
-   * - 1.3
+   * - mongo-1.6
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     - |checkmark|
+     - 
+     - 
+
+   * - mongo-1.5
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - 
+     - 
+
+   * - mongo-1.4
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - 
+     - 
+     - 
+
+   * - mongo-1.3
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - 
+     - 
      - 
 
 .. _reference-compatibility-python:

--- a/source/drivers/php-libraries.txt
+++ b/source/drivers/php-libraries.txt
@@ -102,6 +102,9 @@ Symfony 2
   centralized logger for Symfony applications. See
   `blog post on Symfony <http://obvioushints.blogspot.com/2009/07/my-guess-on-symfony-2.html>`_.
 
+Symfony 1
+~~~~~~~~~
+
 - `sfMongoSessionStorage <https://github.com/brtriver/sfMongoSessionStorage>`_:
   Manages session storage via MongoDB with symfony.
 

--- a/source/drivers/php-libraries.txt
+++ b/source/drivers/php-libraries.txt
@@ -249,6 +249,17 @@ Comfi
 `Comfi <https://github.com/parf/Mongo-PHP-ORM>`_ is a MongoDB PHP ORM
 (part of Comfi.com Homebase Framework)
 
+Mongofill
+~~~~~~~~~
+
+`Mongofill <https://github.com/mongofill/mongofill>`_ is a pure PHP
+implementation of the
+`mongo PECL extension <http://pecl.php.net/package/mongo>`_, which means that it
+can be used with HHVM. Additionally, the
+`mongofill-hhvm <https://github.com/mongofill/mogofill-hhvm>`_ package provides
+a `libbson <https://github.com/mongodb/libbson>`_ extension for HHVM for more
+performant BSON encoding and decoding.
+
 Mongofilesystem
 ~~~~~~~~~~~~~~~
 

--- a/source/drivers/php.txt
+++ b/source/drivers/php.txt
@@ -99,12 +99,22 @@ MongoDB Compatibility
      - MongoDB 2.6
      - MongoDB 3.0
 
-   * - 1.6
+   * - mongodb-1.1
      - |checkmark|
      - |checkmark|
      - |checkmark|
 
-   * - 1.5
+   * - mongodb-1.0
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+
+   * - mongo-1.6
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+
+   * - mongo-1.5
      - |checkmark|
      - |checkmark|
      - 
@@ -121,25 +131,47 @@ Language Compatibility
 .. list-table::
    :header-rows: 1
    :stub-columns: 1
-   :class: compatibility
+   :class: compatibility-large
 
    * - PHP Driver
      - PHP 5.3
      - PHP 5.4
      - PHP 5.5
      - PHP 5.6
+     - PHP 7.0
+     - HHVM 3.9
 
-   * - 1.6
+   * - mongodb-1.1
+     - 
+     - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
 
-   * - 1.5
+   * - mongodb-1.0
+     - 
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - 
+     - |checkmark|
+
+   * - mongo-1.6
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     - 
+     - 
+
+   * - mongo-1.5
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - 
+     - 
 
 .. include:: /includes/extracts/php-driver-compatibility-full-language.rst
 

--- a/source/drivers/php.txt
+++ b/source/drivers/php.txt
@@ -61,7 +61,7 @@ Windows
 ~~~~~~~
 
 - Download the correct driver for your environment from
-  <https://s3.amazonaws.com/drivers.mongodb.org/php/index.html>.
+  <https://pecl.php.net/package/mongo>.
   Thread safe builds are used when running PHP as an Apache module (typical
   installation); non-thread safe builds, which include "nts" in the filename,
   are used for CGI.
@@ -78,7 +78,7 @@ Windows
 - Restart your web server (Apache, IIS, etc.) for the change to take effect.
 
 For more information, see the
-`Windows section of the installation docs <http://us3.php.net/manual/en/mongo.installation.php>`_.
+`Windows section of the installation docs <http://php.net/manual/en/mongo.installation.php#mongo.installation.windows>`_.
 
 Compatibility
 -------------

--- a/source/includes/extracts-driver-compatibility-matrix.yaml
+++ b/source/includes/extracts-driver-compatibility-matrix.yaml
@@ -178,6 +178,10 @@ inherit:
   file: extracts-driver-compatibility-matrix-base.yaml
 replacement:
   driver: MongoDB PHP driver
+post: |
+   In the table below, `mongo <https://pecl.php.net/package/mongo>`_ and
+   `mongodb <https://pecl.php.net/package/mongo>`_ refer to the legacy and new
+   {{driver}}, respectively.
 ---
 ref: php-driver-compatibility-matrix-language
 inherit:
@@ -186,6 +190,10 @@ inherit:
 replacement:
   driver: MongoDB PHP driver
   language: PHP
+post: |
+   In the table below, `mongo <https://pecl.php.net/package/mongo>`_ and
+   `mongodb <https://pecl.php.net/package/mongo>`_ refer to the legacy and new
+   {{driver}}, respectively.
 ---
 ref: php-driver-compatibility-full-mongodb
 inherit:


### PR DESCRIPTION
This adds the next-generation PHP driver ([mongodb-labs/mongo-php-driver-prototype](https://github.com/mongodb-labs/mongo-php-driver-prototype) and [mongodb-labs/mongo-php-hhvm-prototype](https://github.com/mongodb-labs/mongo-php-hhvm-prototype)) to the compatibility tables.

At present, I'm not linking to the next extension at the top of the page; however, we will follow up with another PR as we approach as stable release in the next month.

Some other small fixes are included as well.

/cc @bjori @derickr 