### PR TITLE
Del C Driver's list of compatible C standards

### DIFF
--- a/source/drivers/c.txt
+++ b/source/drivers/c.txt
@@ -58,24 +58,4 @@ MongoDB Compatibility
 
 .. include:: /includes/older-server-versions-unsupported.rst
 
-Language Compatibility
-----------------------
-
-.. include:: /includes/extracts/c-driver-compatibility-matrix-language.rst
-
-.. list-table::
-   :header-rows: 1
-   :stub-columns: 1
-   :class: compatibility
-   :widths: 55 15 15 15
-
-   * - C Driver Versions
-     - C89
-     - C99
-     - C11
-   * - All Versions
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-
 .. include:: /includes/unicode-checkmark.rst


### PR DESCRIPTION
The C driver's compatibility info is in two other places, let's remove this third place.

https://api.mongodb.org/libbson/current/installing.html#supported-platforms
https://api.mongodb.org/c/current/installing.html#supported-platforms

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongodb/docs-ecosystem/325)

<!-- Reviewable:end -->
