### PR TITLE
DOCS-6735: fix trivial typo

### DIFF
--- a/source/tutorial/authenticate-with-csharp-driver.txt
+++ b/source/tutorial/authenticate-with-csharp-driver.txt
@@ -120,8 +120,8 @@ their actual names, which can be different based on your
 distribution. Consider the `documentation from the Mono project
 <http://www.mono-project.com/Config_DllMap>`_ for this process.
 
-Tor the .NET driver, you must map the ``libgsasl-7.dll``
-library.  An example configuration for ubuntu looks like this:
+For the .NET driver, you must map the ``libgsasl-7.dll``
+library.  An example configuration for Ubuntu looks like this:
 
 .. code-block:: xml
 


### PR DESCRIPTION
Fixes a minor typo in the "Authenticating with C#" tutorial.