### PR TITLE
Add missing link to Eve Python framework

### DIFF
--- a/source/tools/http-interfaces.txt
+++ b/source/tools/http-interfaces.txt
@@ -14,7 +14,7 @@ REST Interfaces
 Eve (Python)
 ~~~~~~~~~~~~
 
-Eve is an open source Python REST API framework designed for human beings. It
+`Eve <http://python-eve.org>`_ is an open source Python REST API framework designed for human beings. It
 allows to effortlessly build and deploy highly customizable, fully featured
 RESTful Web Services powered by MongoDB.
 


### PR DESCRIPTION
Somehow I managed to forget adding the resource link.