### PR TITLE
Update ecosystem documentation for the MongoDB Hadoop connector.

### DIFF
--- a/source/tutorial/getting-started-with-hadoop.txt
+++ b/source/tutorial/getting-started-with-hadoop.txt
@@ -19,21 +19,13 @@ Prerequisites
 Hadoop
 ~~~~~~
 
-In order to use the following guide, you should already have Hadoop up
-and running. This can range from a deployed cluster containing multiple
-nodes or a single node pseudo-distributed Hadoop installation running
-locally. As long as you are able to run any of the examples on your
-Hadoop installation, you should be all set. The following versions of
-Hadoop are currently supported:
-
-- 0.23
-- 1.0
-- 1.1
-- 2.2
-- 2.3
-- 2.4
-- CDH4
-- CDH5
+In order to use the following guide, you should already have Hadoop up and
+running. This can range from a deployed cluster containing multiple nodes or a
+single node pseudo-distributed Hadoop installation running locally. As long as
+you are able to run any of the examples on your Hadoop installation, you should
+be all set. The Hadoop connector supports all Apache Hadoop versions 2.X and up,
+including distributions based on these versions such as CDH4, CDH5, and HDP 2.0
+and up.
 
 MongoDB
 ~~~~~~~
@@ -43,7 +35,7 @@ addition, the MongoDB commands should be in your system search path
 (i.e. ``$PATH``).
 
 If your :program:`mongod` requires authorization [#authrequired]_, the user account
-used by the Hadoop connector must have the:authaction:`splitVector` privilege.
+used by the Hadoop connector must have the :authaction:`splitVector` privilege.
    
 To run the examples in this document, use a user 
 that has the :authrole:`clusterManager` role. Add these privileges to
@@ -102,8 +94,8 @@ elevated privileges. See `User and Role Management Tutorials <http://docs.mongod
 Miscellaneous
 ~~~~~~~~~~~~~
 
-In addition to Hadoop, you should also have ``git``, ``python``, and JDK 1.6
-installed.
+In addition to Hadoop, you should also have ``git``, ``python``, and Java 7 or
+greater installed.
 
 Getting the Hadoop Connector
 ----------------------------
@@ -130,7 +122,7 @@ in to mongo.  You can view that data as shown below:
 .. code-block:: sh
 
    $ mongo mongo_hadoop
-   MongoDB shell version: 2.4.9
+   MongoDB shell version: 3.0.4
    connecting to: mongo_hadoop
    > show collections
    system.indexes


### PR DESCRIPTION
- Update what versions of Hadoop are supported.
- Update version of Mongo shell in example.
- Update Java version required.
- Fix markup.