### PR TITLE
DOCS-6994: fix typo

### DIFF
--- a/source/tutorial/model-data-for-ruby-on-rails.txt
+++ b/source/tutorial/model-data-for-ruby-on-rails.txt
@@ -146,9 +146,10 @@ array does not contain the given user id and, if you find such a story,
 perform two atomic updates: first, increment ``votes`` by 1 and then
 push the user id onto the ``voters`` array."
 
-This operation highly efficient; it's also reliable. The one caveat is
-that, because update operations are "fire and forget," you won't get a
-response from the server. But in most cases, this should be a non-issue.
+This operation is highly efficient; it's also reliable. The one caveat
+is that, because update operations are "fire and forget," you won't get
+a response from the server. But in most cases, this should be a
+non-issue.
 
 A MongoMapper implementation of the same update would look like this:
 


### PR DESCRIPTION
Trivial typo in a Ruby-on-Rails tutorial.