### PR TITLE
Update PHP documentation resources links

### DIFF
--- a/source/drivers/php.txt
+++ b/source/drivers/php.txt
@@ -40,11 +40,10 @@ links below point to the documentation for the new **mongodb** extension.
 Documentation Resources
 -----------------------
 
-- `Quick Installation Guide <http://php.net/manual/en/mongodb.installation.php>`_
-- `Installation Tutorials <http://docs.php.net/manual/en/mongodb.tutorial.install.php>`_
+- `Installation Tutorials <http://php.net/manual/en/mongodb.installation.php>`_
 - `Getting Started Tutorials <http://docs.php.net/manual/en/mongodb.tutorial.php>`_
-- `Extension API Reference <http://docs.php.net/manual/en/set.mongodb.php>`_
-- `PHP Library API Reference <http://mongodb.github.io/mongo-php-library/>`_
+- `Extension API Reference <http://php.net/manual/en/set.mongodb.php>`_
+- `PHP Library Documentation <http://mongodb.github.io/mongo-php-library/>`_
 
 Compatibility
 -------------


### PR DESCRIPTION
https://jira.mongodb.org/browse/DOCS-7427

Installation docs were consolidated upstream. Also, library API reference is contained within the top-level docs, so we can change that title to more accurately reflect the destination page.