### PR TITLE
Revert path change for EC2 installation

### DIFF
--- a/source/platforms/amazon-ec2.txt
+++ b/source/platforms/amazon-ec2.txt
@@ -106,7 +106,7 @@ After login, update installed packages, add the MongoDB yum repo, and install Mo
     name=MongoDB Repository
     baseurl=http://downloads-distro.mongodb.org/repo/redhat/os/x86_64
     gpgcheck=0
-    enabled=1" | sudo tee -a /etc/yum/repos.d/mongodb.repo
+    enabled=1" | sudo tee -a /etc/yum.repos.d/mongodb.repo
 
     $ sudo yum install -y mongodb-org-server mongodb-org-shell mongodb-org-tools
 


### PR DESCRIPTION
changed path /etc/yum/repos.d/mongodb.repo doesn't work 
old path /etc/yum.repos.d/mongodb.repo does work

![screen shot 2016-06-23 at 09 57 32](https://cloud.githubusercontent.com/assets/8886969/16297510/0a073272-3929-11e6-96f9-55c5d88da0cc.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs-ecosystem/373)
<!-- Reviewable:end -->
