### PR TITLE
Update PHP library and extension doc links

### DIFF
--- a/source/drivers/php.txt
+++ b/source/drivers/php.txt
@@ -12,12 +12,13 @@ PHP MongoDB Driver
    :depth: 1
    :class: twocols
 
-For the official MongoDB PHP reference, see:
+For the official MongoDB PHP Driver reference, see:
 
-- `MongoDB PHP Documentation
-  <http://mongodb.github.io/mongo-php-library/?jmp=docs>`_
+- `MongoDB PHP Library Documentation
+  <https://docs.mongodb.com/php-library/>`_
 
-- `MongoDB PHP API Reference <http://mongodb.github.io/mongo-php-library/api/>`_
+- `MongoDB PHP and HHVM Extension Documentation
+  <http://php.net/manual/en/set.mongodb.php>`_
 
 Access MongoDB from PHP
 -----------------------


### PR DESCRIPTION
In https://github.com/mongodb/mongo-php-library/pull/275 (for [PHPLIB-230](https://jira.mongodb.org/browse/PHPLIB-230)), I've removed the PHP library's `gh-pages` branch and added redirects to the manual documentation. This was one more place that we were linking to the old docs.

Note: There is no direct replacement for the generated API documentation, but the API reference in the current manual is superior anyway. It made sense to link to the `mongodb` extension documentation in its place.