### PR TITLE
3.4 driver compat diagram updates

### DIFF
--- a/source/drivers/cpp.txt
+++ b/source/drivers/cpp.txt
@@ -31,31 +31,41 @@ MongoDB Compatibility
    :header-rows: 1
    :stub-columns: 1
    :class: compatibility
-   :widths: 37 21 21 21 21
 
    * - C++ Driver Version
      - MongoDB 2.4
      - MongoDB 2.6
      - MongoDB 3.0
      - MongoDB 3.2
+     - MongoDB 3.4
 
-   * - C++11 0.3.0
+   * - C++11 3.1
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     - |checkmark|
+
+   * - C++11 3.0
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - 
 
    * - legacy-1.1.0+
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     - 
 
    * - legacy-1.0.0+
      - |checkmark|
      - |checkmark|
      - |checkmark|
      -
+     - 
 
 .. include:: /includes/older-server-versions-unsupported.rst
 
@@ -75,12 +85,17 @@ Language Compatibility
      - C++11
      - C++14
 
-   * - legacy-1.0.0+
-     - |checkmark|
+   * - mongocxx 3.1.x
+     - 
      - |checkmark|
      - |checkmark|
 
-   * - legacy-0.0-26compat-2.6.4+
+   * - mongocxx 3.0.x
+     - 
+     - |checkmark|
+     - |checkmark|
+
+   * - legacy-1.0.0+
      - |checkmark|
      - |checkmark|
      - |checkmark|

--- a/source/drivers/csharp.txt
+++ b/source/drivers/csharp.txt
@@ -64,24 +64,33 @@ MongoDB Compatibility
    :header-rows: 1
    :stub-columns: 1
    :class: compatibility
-   :widths: 25 15 15 15 15
 
    * - C#/.NET Driver Version
      - MongoDB 2.4
      - MongoDB 2.6
      - MongoDB 3.0
      - MongoDB 3.2
+     - MongoDB 3.4
+
+   * - Version 2.3
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
 
    * - Version 2.2
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
 
    * - Version 2.0
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
      -
 
    * - Version 1.11
@@ -89,11 +98,13 @@ MongoDB Compatibility
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
 
    * - Version 1.10
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
      -
 
 .. include:: /includes/extracts/csharp-driver-compatibility-full-mongodb.rst
@@ -109,35 +120,42 @@ MongoDB Compatibility
    :header-rows: 1
    :stub-columns: 1
    :class: compatibility
-   :widths: 30 10 10 10 10 10
 
    * - Driver Version
      - .NET 3.5
      - .NET 4.0
      - .NET 4.5
-     - Mono 2.10
-     - Mono 3.x
+     - .NET Core
+
+   * - Version 2.3
+     -
+     -
+     - |checkmark|
+     - |checkmark|   
+
+   * - Version 2.2
+     -
+     -
+     - |checkmark|
+     -
 
    * - Version 2.0
      -
      -
      - |checkmark|
      -
-     - |checkmark|
 
    * - Version 1.11
      - |checkmark|
      - |checkmark|
      - |checkmark|
-     - |checkmark|
-     - |checkmark|
+     -
 
    * - Version 1.10
      - |checkmark|
      - |checkmark|
      - |checkmark|
-     - |checkmark|
-     - |checkmark|
+     -
 
 .. include:: /includes/extracts/csharp-driver-compatibility-full-language.rst
 

--- a/source/drivers/driver-compatibility-reference.txt
+++ b/source/drivers/driver-compatibility-reference.txt
@@ -708,7 +708,7 @@ MongoDB Compatibility
      - MongoDB 3.2
      - MongoDB 3.4
 
-   * - mongodb-1.2
+   * - PHPLIB 1.1 + mongodb-1.2
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -784,10 +784,14 @@ Language Compatibility
      - PHP 5.5
      - PHP 5.6
      - PHP 7.0
-     - HHVM 3.9
+     - PHP 7.1
+     - HHVM 3.12
+     - HHVM 3.15
 
    * - mongodb-1.2
      -
+     - |checkmark|
+     - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -801,6 +805,8 @@ Language Compatibility
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     - |checkmark|
+     - |checkmark|
 
    * - mongodb-1.0
      -
@@ -808,6 +814,8 @@ Language Compatibility
      - |checkmark|
      - |checkmark|
      -
+     -
+     - |checkmark|
      - |checkmark|
 
    * - mongo-1.6
@@ -815,6 +823,8 @@ Language Compatibility
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
+     -
      -
      -
 
@@ -825,6 +835,8 @@ Language Compatibility
      - |checkmark|
      -
      -
+     -
+     -
 
    * - mongo-1.4
      - |checkmark|
@@ -833,11 +845,15 @@ Language Compatibility
      -
      -
      -
+     -
+     -
 
    * - mongo-1.3
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
+     -
      -
      -
      -
@@ -1184,7 +1200,7 @@ MongoDB Compatibility
      - MongoDB 2.6
      - MongoDB 3.0
      - MongoDB 3.2
-     - MongoDb 3.4
+     - MongoDB 3.4
 
    * - 1.0
      - |checkmark|
@@ -1243,7 +1259,7 @@ MongoDB Compatibility
      -
 
 - Motor 1.0 wraps PyMongo 3.3+
-- Motor 0.7 wraps PyMongo 2.9.4+
+- Motor 0.7 wraps PyMongo >=2.9.4 and <3.0
 - Motor 0.6 wraps PyMongo 2.8
 - Motor 0.5 wraps PyMongo 2.8
 - Motor 0.4 wraps PyMongo 2.8
@@ -1272,11 +1288,9 @@ Language Compatibility
      - Python 3.3
      - Python 3.4
      - Python 3.5
-     - Python 3.6
 
    * - 1.0
      -
-     - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -1290,11 +1304,9 @@ Language Compatibility
      - |checkmark|
      - |checkmark|
      - |checkmark|
-     - |checkmark|
 
    * - 0.6
      -
-     - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -1308,7 +1320,6 @@ Language Compatibility
      - |checkmark|
      - |checkmark|
      - |checkmark|
-     - |checkmark|
 
    * - 0.4
      -
@@ -1316,7 +1327,6 @@ Language Compatibility
      - |checkmark|
      - |checkmark|
      - |checkmark|
-     -
      -
 
    * - 0.3
@@ -1326,14 +1336,12 @@ Language Compatibility
      - |checkmark|
      - |checkmark|
      -
-     -
 
    * - 0.2
      -
      - |checkmark|
      - |checkmark|
      - |checkmark|
-     -
      -
      -
 
@@ -1344,10 +1352,9 @@ Language Compatibility
      - |checkmark|
      -
      -
-     -
 
 - Motor 1.0 wraps PyMongo 3.3+
-- Motor 0.7 wraps PyMongo 2.9.4+
+- Motor 0.7 wraps PyMongo >=2.9.4 and <3.0
 - Motor 0.6 wraps PyMongo 2.8
 - Motor 0.5 wraps PyMongo 2.8
 - Motor 0.4 wraps PyMongo 2.8

--- a/source/drivers/driver-compatibility-reference.txt
+++ b/source/drivers/driver-compatibility-reference.txt
@@ -463,14 +463,6 @@ MongoDB Compatibility
      - |checkmark|
      - |checkmark|
 
-
-   * - >=2.1.0
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     -
-
    * - >=2.0.14
      - |checkmark|
      - |checkmark|
@@ -525,8 +517,10 @@ Language Compatibility
      - Node.js v0.10.X
      - Node.js v0.12.X
      - Node.js v4.X.X
+     - Node.js v6.X.X
 
-   * - 2.2.12
+   * - 2.2.X
+     - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -537,8 +531,10 @@ Language Compatibility
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     - |checkmark|
 
    * - 2.0.X
+     - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -549,10 +545,12 @@ Language Compatibility
      - |checkmark|
      - |checkmark|
      -
+     -
 
    * - 1.4.X
      - |checkmark|
      - |checkmark|
+     -
      -
      -
 
@@ -561,10 +559,12 @@ Language Compatibility
      - |checkmark|
      -
      -
+     -
 
    * - 1.2.X
      - |checkmark|
      - |checkmark|
+     -
      -
      -
 

--- a/source/drivers/driver-compatibility-reference.txt
+++ b/source/drivers/driver-compatibility-reference.txt
@@ -1420,6 +1420,13 @@ MongoDB Compatibility
      - |checkmark|
      -
 
+   * - 2.1
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     -
+     - 
+
    * - 2.0
      - |checkmark|
      - |checkmark|
@@ -1495,7 +1502,7 @@ Language Compatibility
      - |checkmark|
      - |checkmark|
 
-   * - 2.0
+   * - 2.3
      -
      - |checkmark|
      - |checkmark|
@@ -1504,7 +1511,34 @@ Language Compatibility
      - |checkmark|
      - |checkmark|
 
-   * - 1.12 - 1.9
+   * - 2.2
+     -
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+
+   * - 2.1
+     -
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     -
+     - |checkmark|
+
+   * - 2.0
+     -
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - 
+     - 
+     - |checkmark|
+
+   * - 1.9 - 1.12
      - |checkmark|
      - |checkmark|
      - |checkmark|

--- a/source/drivers/driver-compatibility-reference.txt
+++ b/source/drivers/driver-compatibility-reference.txt
@@ -806,7 +806,7 @@ Language Compatibility
      - |checkmark|
      - |checkmark|
      - |checkmark|
-     - |checkmark|
+     -
 
    * - mongodb-1.0
      -
@@ -816,7 +816,7 @@ Language Compatibility
      -
      -
      - |checkmark|
-     - |checkmark|
+     - 
 
    * - mongo-1.6
      - |checkmark|

--- a/source/drivers/driver-compatibility-reference.txt
+++ b/source/drivers/driver-compatibility-reference.txt
@@ -26,30 +26,40 @@ MongoDB Compatibility
    :header-rows: 1
    :stub-columns: 1
    :class: compatibility
-   :widths: 25 20 20 20 20
 
    * - C Driver Version
      - MongoDB 2.4
      - MongoDB 2.6
      - MongoDB 3.0
      - MongoDB 3.2
+     - MongoDB 3.4
+
+   * - Version 1.5
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
 
    * - Version 1.3
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
 
    * - Version 1.1.0
      - |checkmark|
      - |checkmark|
      - |checkmark|
      -
+     -
 
    * - Version 1.0.0
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
      -
 
 .. include:: /includes/older-server-versions-unsupported.rst
@@ -92,37 +102,41 @@ MongoDB Compatibility
    :header-rows: 1
    :stub-columns: 1
    :class: compatibility
-   :widths: 37 21 21 21 21
 
    * - C++ Driver Version
      - MongoDB 2.4
      - MongoDB 2.6
      - MongoDB 3.0
      - MongoDB 3.2
+     - MongoDB 3.4
 
-   * - C++11 0.3.0
+   * - mongocxx 3.1.x
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     - |checkmark|
+
+   * - mongocxx 3.0.x
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - 
 
    * - legacy-1.1.0+
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     - 
 
    * - legacy-1.0.0+
      - |checkmark|
      - |checkmark|
      - |checkmark|
      -
-
-   * - legacy-0.0-26compat-2.6.4+
-     -
-     - |checkmark|
-     -
-     -
+     - 
 
 .. include:: /includes/older-server-versions-unsupported.rst
 
@@ -144,12 +158,17 @@ Language Compatibility
      - C++11
      - C++14
 
-   * - legacy-1.0.0+
-     - |checkmark|
+   * - mongocxx 3.1.x
+     - 
      - |checkmark|
      - |checkmark|
 
-   * - legacy-0.0-26compat-2.6.4+
+   * - mongocxx 3.0.x
+     - 
+     - |checkmark|
+     - |checkmark|
+
+   * - legacy-1.0.0+
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -170,24 +189,33 @@ MongoDB Compatibility
    :header-rows: 1
    :stub-columns: 1
    :class: compatibility
-   :widths: 25 15 15 15 15
 
    * - C#/.NET Driver Version
      - MongoDB 2.4
      - MongoDB 2.6
      - MongoDB 3.0
      - MongoDB 3.2
+     - MongoDB 3.4
+
+   * - Version 2.3
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
 
    * - Version 2.2
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
 
    * - Version 2.0
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
      -
 
    * - Version 1.11
@@ -195,22 +223,12 @@ MongoDB Compatibility
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
 
    * - Version 1.10
      - |checkmark|
      - |checkmark|
      - |checkmark|
-     -
-
-   * - Versions 1.9
-     - |checkmark|
-     - |checkmark|
-     -
-     -
-
-   * - Versions 1.8
-     - |checkmark|
-     -
      -
      -
 
@@ -227,38 +245,38 @@ Language Compatibility
    :header-rows: 1
    :stub-columns: 1
    :class: compatibility
-   :widths: 30 10 10 10 10 10
 
    * - Driver Version
      - .NET 3.5
      - .NET 4.0
      - .NET 4.5
-     - Mono 2.10
-     - Mono 3.x
+     - .NET Core
+
+   * - Version 2.3
+     -
+     -
+     - |checkmark|
+     - |checkmark|   
+
+   * - Version 2.2
+     -
+     -
+     - |checkmark|
+     -
 
    * - Version 2.0
      -
      -
      - |checkmark|
      -
-     - |checkmark|
 
    * - Version 1.11
      - |checkmark|
      - |checkmark|
      - |checkmark|
-     - |checkmark|
-     - |checkmark|
+     -
 
    * - Version 1.10
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-
-   * - Versions <= 1.9.2
-     - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -286,6 +304,14 @@ MongoDB Compatibility
      - MongoDB 2.6
      - MongoDB 3.0
      - MongoDB 3.2
+     - MongoDB 3.4
+
+   * - Version 3.4
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
 
 
    * - Version 3.3
@@ -293,17 +319,20 @@ MongoDB Compatibility
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
 
    * - Version 3.2
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
 
    * - Version 3.1
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
      -
 
    * - Version 3.0
@@ -311,17 +340,20 @@ MongoDB Compatibility
      - |checkmark|
      - |checkmark|
      -
+     -
 
    * - Version 2.14
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|  [*]_
+     -
 
    * - Version 2.13
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
      -
 
    * - Version 2.12
@@ -329,9 +361,11 @@ MongoDB Compatibility
      - |checkmark|
      -
      -
+     -
 
    * - Version 2.11
      - |checkmark|
+     -
      -
      -
      -
@@ -361,6 +395,12 @@ Language Compatibility
      - Java 6
      - Java 7
      - Java 8
+
+   * - Version 3.4
+     -
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
 
    * - Version 3.3
      -
@@ -407,7 +447,6 @@ MongoDB Compatibility
 .. list-table::
    :header-rows: 1
    :stub-columns: 1
-   :widths: 20 20 20 20 20
    :class: compatibility
 
    * - Node.js Driver
@@ -415,17 +454,28 @@ MongoDB Compatibility
      - MongoDB 2.6
      - MongoDB 3.0
      - MongoDB 3.2
+     - MongoDB 3.4
+
+   * - >=2.2.12
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+
 
    * - >=2.1.0
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
 
    * - >=2.0.14
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
      -
 
    * - >=1.4.29
@@ -433,10 +483,12 @@ MongoDB Compatibility
      - |checkmark|
      - |checkmark|
      -
+     -
 
    * - 1.4.X
      - |checkmark|
      - |checkmark|
+     -
      -
      -
 
@@ -445,9 +497,11 @@ MongoDB Compatibility
      -
      -
      -
+     -
 
    * - 1.2.X
      - |checkmark|
+     -
      -
      -
      -
@@ -472,6 +526,12 @@ Language Compatibility
      - Node.js v0.12.X
      - Node.js v4.X.X
 
+   * - 2.2.12
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+   
    * - 2.1.X
      - |checkmark|
      - |checkmark|
@@ -530,29 +590,34 @@ MongoDB Compatibility
      - MongoDB 2.6
      - MongoDB 3.0
      - MongoDB 3.2
+     - MongoDB 3.4
+
+   * - 1.6.x
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
 
    * - 1.4.x
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
 
    * - 1.2.x
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
 
    * - 1.0.x
      - |checkmark|
      - |checkmark|
      - |checkmark|
      -
-
-   * - 0.708.x
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
      -
 
 .. include:: /includes/older-server-versions-unsupported.rst
@@ -578,7 +643,16 @@ Language Compatibility
      - 5.20
      - 5.22
      - 5.24
-
+     
+   * - 1.6.x
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
 
    * - 1.4.x
      - |checkmark|
@@ -610,26 +684,6 @@ Language Compatibility
      - |checkmark|
      - |checkmark|
 
-   * - 0.708.x - 0.701.x
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-
-   * - 0.503.x
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-
 .. _reference-compatibility-php:
 
 PHP Driver Compatibility
@@ -645,7 +699,6 @@ MongoDB Compatibility
 .. list-table::
    :header-rows: 1
    :stub-columns: 1
-   :widths: 20 20 20 20 20
    :class: compatibility
 
    * - PHP Driver
@@ -653,23 +706,34 @@ MongoDB Compatibility
      - MongoDB 2.6
      - MongoDB 3.0
      - MongoDB 3.2
+     - MongoDB 3.4
+
+   * - mongodb-1.2
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
 
    * - PHPLIB 1.0 + mongodb-1.1
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
 
    * - mongodb-1.1
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
 
    * - mongodb-1.0
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
      -
 
    * - mongo-1.6
@@ -677,10 +741,12 @@ MongoDB Compatibility
      - |checkmark|
      - |checkmark|
      -
+     -
 
    * - mongo-1.5
      - |checkmark|
      - |checkmark|
+     -
      -
      -
 
@@ -689,9 +755,11 @@ MongoDB Compatibility
      - |checkmark|
      -
      -
+     -
 
    * - mongo-1.3
      - |checkmark|
+     -
      -
      -
      -
@@ -717,6 +785,14 @@ Language Compatibility
      - PHP 5.6
      - PHP 7.0
      - HHVM 3.9
+
+   * - mongodb-1.2
+     -
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
 
    * - mongodb-1.1
      -
@@ -781,7 +857,6 @@ MongoDB Compatibility
 .. list-table::
    :header-rows: 1
    :stub-columns: 1
-   :widths: 20 20 20 20 20
    :class: compatibility
 
    * - Python Driver
@@ -789,23 +864,34 @@ MongoDB Compatibility
      - MongoDB 2.6
      - MongoDB 3.0
      - MongoDB 3.2
+     - MongoDB 3.4
+
+   * - 3.4
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
 
    * - 3.3
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
 
    * - 3.2
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
 
    * - 3.1
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
      -
 
    * - 3.0
@@ -813,11 +899,13 @@ MongoDB Compatibility
      - |checkmark|
      - |checkmark|
      -
+     -
 
    * - 2.9
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
      -
 
    * - 2.8
@@ -825,10 +913,12 @@ MongoDB Compatibility
      - |checkmark|
      - |checkmark|
      -
+     -
 
    * - 2.7
      - |checkmark|
      - |checkmark|
+     -
      -
      -
 
@@ -837,9 +927,11 @@ MongoDB Compatibility
      -
      -
      -
+     -
 
    * - 2.5
      - |checkmark|
+     -
      -
      -
      -
@@ -866,6 +958,12 @@ Python 2 Compatibility
      - Python 2.5, Jython 2.5
      - Python 2.6
      - Python 2.7, PyPy
+
+   * - 3.4
+     -
+     - 
+     - |checkmark|
+     - |checkmark|
 
    * - 3.3
      -
@@ -955,6 +1053,14 @@ Python 3 Compatibility
      - Python 3.4
      - Python 3.5
 
+   * - 3.4
+     -
+     -
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+
    * - 3.3
      -
      -
@@ -1023,7 +1129,7 @@ Python 3 Compatibility
      - |checkmark|
      - |checkmark|
      - |checkmark|
-     -
+     - |checkmark|
      -
      -
 
@@ -1077,27 +1183,69 @@ MongoDB Compatibility
      - MongoDB 2.4
      - MongoDB 2.6
      - MongoDB 3.0
+     - MongoDB 3.2
+     - MongoDb 3.4
+
+   * - 1.0
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+
+   * - 0.7
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     -
+
+   * - 0.6
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     -
+     -
+
+   * - 0.5
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     -
+     -
 
    * - 0.4
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
+     -
 
    * - 0.3
      - |checkmark|
      - |checkmark|
+     -
+     -
      -
 
    * - 0.2
      - |checkmark|
      - |checkmark|
      -
+     -
+     -
 
    * - 0.1
      - |checkmark|
      -
      -
+     -
+     -
 
+- Motor 1.0 wraps PyMongo 3.3+
+- Motor 0.7 wraps PyMongo 2.9.4+
+- Motor 0.6 wraps PyMongo 2.8
+- Motor 0.5 wraps PyMongo 2.8
 - Motor 0.4 wraps PyMongo 2.8
 - Motor 0.3 wraps PyMongo 2.7.1
 - Motor 0.2 wraps PyMongo 2.7.0
@@ -1121,47 +1269,87 @@ Language Compatibility
      - Python 2.5
      - Python 2.6
      - Python 2.7
-     - Python 3.1
-     - Python 3.2
      - Python 3.3
      - Python 3.4
+     - Python 3.5
+     - Python 3.6
+
+   * - 1.0
+     -
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+
+   * - 0.7
+     -
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+
+   * - 0.6
+     -
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+
+   * - 0.5
+     -
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
 
    * - 0.4
      -
      - |checkmark|
      - |checkmark|
-     -
-     -
      - |checkmark|
      - |checkmark|
+     -
+     -
 
    * - 0.3
      -
      - |checkmark|
      - |checkmark|
-     -
-     -
      - |checkmark|
      - |checkmark|
+     -
+     -
 
    * - 0.2
      -
      - |checkmark|
      - |checkmark|
-     -
-     -
      - |checkmark|
+     -
+     -
      -
 
    * - 0.1
      - |checkmark|
      - |checkmark|
      - |checkmark|
-     -
-     -
      - |checkmark|
      -
+     -
+     -
 
+- Motor 1.0 wraps PyMongo 3.3+
+- Motor 0.7 wraps PyMongo 2.9.4+
+- Motor 0.6 wraps PyMongo 2.8
+- Motor 0.5 wraps PyMongo 2.8
 - Motor 0.4 wraps PyMongo 2.8
 - Motor 0.3 wraps PyMongo 2.7.1
 - Motor 0.2 wraps PyMongo 2.7.0
@@ -1169,8 +1357,12 @@ Language Compatibility
 
 .. note::
 
-   - Motor requires Tornado, and supports the same version of Python
-     as its supported Tornado versions do.
+   - Motor version 0.5 and earlier requires Tornado, and supports the
+     same version of Python as its supported Tornado versions do.
+
+   - For asyncio support, Motor requires Python 3.4+, or
+     Python 3.3 with the `asyncio package from PyPI 
+     <https://pypi.python.org/pypi/asyncio>`_.
 
    - PyPy is not supported as it runs Motor code slowly.
 
@@ -1191,7 +1383,6 @@ MongoDB Compatibility
 .. list-table::
    :header-rows: 1
    :stub-columns: 1
-   :widths: 20 20 20 20 20
    :class: compatibility
 
    * - Ruby Driver
@@ -1199,17 +1390,34 @@ MongoDB Compatibility
      - MongoDB 2.6
      - MongoDB 3.0
      - MongoDB 3.2
+     - MongoDB 3.4
+
+   * - 2.4
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+
+   * - 2.3
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     -
 
    * - 2.2
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
 
    * - 2.0
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
      -
 
    * - 1.12
@@ -1217,10 +1425,12 @@ MongoDB Compatibility
      - |checkmark|
      - |checkmark|
      -
+     -
 
    * - 1.11
      - |checkmark|
      - |checkmark|
+     -
      -
      -
 
@@ -1229,9 +1439,11 @@ MongoDB Compatibility
      - |checkmark|
      -
      -
+     -
 
    * - 1.9
      - |checkmark|
+     -
      -
      -
      -
@@ -1241,6 +1453,8 @@ MongoDB Compatibility
      -
      -
      -
+     -
+
 
 .. include:: /includes/older-server-versions-unsupported.rst
 
@@ -1261,10 +1475,23 @@ Language Compatibility
      - Ruby 1.9
      - Ruby 2.0
      - Ruby 2.1
+     - Ruby 2.2
+     - Ruby 2.3
      - JRuby
+
+   * - 2.4
+     -
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
 
    * - 2.0
      -
+     - |checkmark|
+     - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -1275,6 +1502,8 @@ Language Compatibility
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
+     -
      - |checkmark|
 
    * - 1.8
@@ -1282,11 +1511,15 @@ Language Compatibility
      - |checkmark|
      - |checkmark|
      -
+     -
+     -
      - |checkmark|
 
    * - 1.7
      - |checkmark|
      - |checkmark|
+     -
+     -
      -
      -
      - |checkmark|
@@ -1296,7 +1529,10 @@ Language Compatibility
      - |checkmark|
      -
      -
+     -
+     -
      - |checkmark|
+
 
 Scala Driver Compatibility
 --------------------------
@@ -1311,7 +1547,6 @@ MongoDB Compatibility
 .. list-table::
    :header-rows: 1
    :stub-columns: 1
-   :widths: 20 20 20 20 20
    :class: compatibility
 
    * - Scala Driver
@@ -1319,17 +1554,27 @@ MongoDB Compatibility
      - MongoDB 2.6
      - MongoDB 3.0
      - MongoDB 3.2
+     - MongoDB 3.4
+
+   * - 1.2
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
 
    * - 1.1
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
 
    * - 1.0
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
      -
 
 .. include:: /includes/older-server-versions-unsupported.rst

--- a/source/drivers/java.txt
+++ b/source/drivers/java.txt
@@ -81,24 +81,35 @@ MongoDB Compatibility
      - MongoDB 2.6
      - MongoDB 3.0
      - MongoDB 3.2
+     - MongoDB 3.4
 
    * - Version 3.3
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     - |checkmark|
+
+   * - Version 3.3
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     -
 
    * - Version 3.2
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
 
    * - Version 2.14
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark| [*]_
+     -
 
 .. include:: /includes/extracts/java-driver-compatibility-full-mongodb.rst
 

--- a/source/drivers/node-js.txt
+++ b/source/drivers/node-js.txt
@@ -64,8 +64,10 @@ MongoDB Compatibility
      - MongoDB 2.6
      - MongoDB 3.0
      - MongoDB 3.2
+     - MongoDB 3.4
 
-   * - >=2.1.0
+   * - >=2.2.12
+     - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -75,6 +77,7 @@ MongoDB Compatibility
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
      -
 
 .. include:: /includes/extracts/node-driver-compatibility-full-mongodb.rst
@@ -96,14 +99,24 @@ Language Compatibility
      - Node.js v0.10.X
      - Node.js v0.12.X
      - Node.js v4.X.X
+     - Node.js v6.X.X
+
+   * - 2.2.X
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
 
    * - 2.1.X
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     - |checkmark|
 
    * - 2.0.X
+     - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|

--- a/source/drivers/node-js.txt
+++ b/source/drivers/node-js.txt
@@ -56,7 +56,6 @@ MongoDB Compatibility
 .. list-table::
    :header-rows: 1
    :stub-columns: 1
-   :widths: 20 20 20 20 20
    :class: compatibility
 
    * - Node.js Driver

--- a/source/drivers/perl.txt
+++ b/source/drivers/perl.txt
@@ -42,24 +42,34 @@ MongoDB Compatibility
      - MongoDB 2.6
      - MongoDB 3.0
      - MongoDB 3.2
+     - MongoDB 3.4
 
+   * - 1.6.x
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     -
 
    * - 1.4.x
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
 
    * - 1.2.x
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
 
    * - 1.0.x
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
      -
 
 .. include:: /includes/older-server-versions-unsupported.rst
@@ -83,6 +93,16 @@ Language Compatibility
      - 5.20
      - 5.22
      - 5.24
+
+   * - 1.6.x
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
 
    * - 1.4.x
      - |checkmark|

--- a/source/drivers/php.txt
+++ b/source/drivers/php.txt
@@ -65,7 +65,7 @@ MongoDB Compatibility
      - MongoDB 3.2
      - MongoDB 3.4
 
-   * - mongodb-1.2
+   * - PHPLIB 1.1 + mongodb-1.2
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -127,10 +127,14 @@ Language Compatibility
      - PHP 5.5
      - PHP 5.6
      - PHP 7.0
-     - HHVM 3.9
+     - PHP 7.1
+     - HHVM 3.12
+     - HHVM 3.15
 
    * - mongodb-1.2
      -
+     - |checkmark|
+     - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -144,6 +148,8 @@ Language Compatibility
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     - |checkmark|
+     - |checkmark|
 
    * - mongodb-1.0
      - 
@@ -151,6 +157,8 @@ Language Compatibility
      - |checkmark|
      - |checkmark|
      - 
+     - 
+     - |checkmark|
      - |checkmark|
 
    * - mongo-1.6
@@ -160,12 +168,16 @@ Language Compatibility
      - |checkmark|
      - 
      - 
+     - 
+     - 
 
    * - mongo-1.5
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     - 
+     - 
      - 
      - 
 

--- a/source/drivers/php.txt
+++ b/source/drivers/php.txt
@@ -56,7 +56,6 @@ MongoDB Compatibility
 .. list-table::
    :header-rows: 1
    :stub-columns: 1
-   :widths: 20 20 20 20 20
    :class: compatibility
 
    * - PHP Driver
@@ -64,23 +63,34 @@ MongoDB Compatibility
      - MongoDB 2.6
      - MongoDB 3.0
      - MongoDB 3.2
+     - MongoDB 3.4
+
+   * - mongodb-1.2
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
 
    * - PHPLIB 1.0 + mongodb-1.1
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
 
    * - mongodb-1.1
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
 
    * - mongodb-1.0
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
      -
 
    * - mongo-1.6
@@ -88,10 +98,12 @@ MongoDB Compatibility
      - |checkmark|
      - |checkmark|
      -
+     -
 
    * - mongo-1.5
      - |checkmark|
      - |checkmark|
+     -
      - 
      - 
 
@@ -116,6 +128,14 @@ Language Compatibility
      - PHP 5.6
      - PHP 7.0
      - HHVM 3.9
+
+   * - mongodb-1.2
+     -
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
 
    * - mongodb-1.1
      -

--- a/source/drivers/php.txt
+++ b/source/drivers/php.txt
@@ -149,7 +149,7 @@ Language Compatibility
      - |checkmark|
      - |checkmark|
      - |checkmark|
-     - |checkmark|
+     -
 
    * - mongodb-1.0
      - 
@@ -159,7 +159,7 @@ Language Compatibility
      - 
      - 
      - |checkmark|
-     - |checkmark|
+     -
 
    * - mongo-1.6
      - |checkmark|

--- a/source/drivers/python.txt
+++ b/source/drivers/python.txt
@@ -42,7 +42,6 @@ MongoDB Compatibility
 .. list-table::
    :header-rows: 1
    :stub-columns: 1
-   :widths: 20 20 20 20 20
    :class: compatibility
 
    * - Python Driver
@@ -50,24 +49,35 @@ MongoDB Compatibility
      - MongoDB 2.6
      - MongoDB 3.0
      - MongoDB 3.2
+     - MongoDB 3.4
+
+   * - 3.4
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
 
    * - 3.3
      - |checkmark|
      - |checkmark|
      - |checkmark|
-     - |checkmark|     
+     - |checkmark|
+     -  
 
    * - 3.2
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
 
    * - 2.9
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
 
 .. include:: /includes/extracts/python-driver-compatibility-full-mongodb.rst
 
@@ -96,6 +106,12 @@ Python 2 Compatibility
      - Python 2.5, Jython 2.5
      - Python 2.6
      - Python 2.7, PyPy
+
+   * - 3.4
+     -
+     - 
+     - |checkmark|
+     - |checkmark|
 
    * - 3.3
      -
@@ -131,6 +147,14 @@ Python 3 Compatibility
      - Python 3.3
      - Python 3.4
      - Python 3.5
+
+   * - 3.4
+     -
+     -
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
 
    * - 3.3
      -
@@ -208,17 +232,39 @@ MongoDB Compatibility
      - MongoDB 2.4
      - MongoDB 2.6
      - MongoDB 3.0
+     - MongoDB 3.2
+     - MongoDB 3.4
+     
+   * - 1.0
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+   
+   * - 0.7
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     -
 
    * - 0.4
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
+     -
 
    * - 0.3
      - |checkmark|
      - |checkmark|
+     -
+     -
      - 
 
+- Motor 1.0 wraps PyMongo 3.3+
+- Motor 0.7 wraps PyMongo 2.9.4+
 - Motor 0.4 wraps PyMongo 2.8
 - Motor 0.3 wraps PyMongo 2.7.1
 
@@ -243,6 +289,28 @@ Language Compatibility
      - Python 3.2
      - Python 3.3
      - Python 3.4
+     - Python 3.5
+     - Python 3.6
+
+   * - 1.0
+     - |checkmark|
+     - |checkmark|
+     - 
+     - 
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+
+   * - 0.7
+     - |checkmark|
+     - |checkmark|
+     - 
+     - 
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
 
    * - 0.4
      - |checkmark|
@@ -251,6 +319,8 @@ Language Compatibility
      - 
      - |checkmark|
      - |checkmark|
+     -
+     -
 
    * - 0.3
      - |checkmark|
@@ -259,7 +329,11 @@ Language Compatibility
      - 
      - |checkmark|
      - |checkmark|
+     -
+     -
 
+- Motor 1.0 wraps PyMongo 3.3+
+- Motor 0.7 wraps PyMongo 2.9.4+
 - Motor 0.4 wraps PyMongo 2.8
 - Motor 0.3 wraps PyMongo 2.7.1
 

--- a/source/drivers/python.txt
+++ b/source/drivers/python.txt
@@ -290,14 +290,12 @@ Language Compatibility
      - Python 3.3
      - Python 3.4
      - Python 3.5
-     - Python 3.6
 
    * - 1.0
      - |checkmark|
      - |checkmark|
      - 
      - 
-     - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -310,7 +308,6 @@ Language Compatibility
      - |checkmark|
      - |checkmark|
      - |checkmark|
-     - |checkmark|
 
    * - 0.4
      - |checkmark|
@@ -319,7 +316,6 @@ Language Compatibility
      - 
      - |checkmark|
      - |checkmark|
-     -
      -
 
    * - 0.3
@@ -330,10 +326,9 @@ Language Compatibility
      - |checkmark|
      - |checkmark|
      -
-     -
 
 - Motor 1.0 wraps PyMongo 3.3+
-- Motor 0.7 wraps PyMongo 2.9.4+
+- Motor 0.7 wraps PyMongo >=2.9.4 and <3.0
 - Motor 0.4 wraps PyMongo 2.8
 - Motor 0.3 wraps PyMongo 2.7.1
 

--- a/source/drivers/python.txt
+++ b/source/drivers/python.txt
@@ -264,7 +264,7 @@ MongoDB Compatibility
      - 
 
 - Motor 1.0 wraps PyMongo 3.3+
-- Motor 0.7 wraps PyMongo 2.9.4+
+- Motor 0.7 wraps PyMongo >=2.9.4 and <3.0
 - Motor 0.4 wraps PyMongo 2.8
 - Motor 0.3 wraps PyMongo 2.7.1
 

--- a/source/drivers/scala.txt
+++ b/source/drivers/scala.txt
@@ -39,7 +39,6 @@ MongoDB Compatibility
 .. list-table::
    :header-rows: 1
    :stub-columns: 1
-   :widths: 20 20 20 20 20
    :class: compatibility
 
    * - Scala Driver
@@ -47,17 +46,27 @@ MongoDB Compatibility
      - MongoDB 2.6
      - MongoDB 3.0
      - MongoDB 3.2
+     - MongoDB 3.4
+
+   * - 1.2
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
 
    * - 1.1
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
 
    * - 1.0
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
      -
 
 .. include:: /includes/extracts/scala-driver-compatibility-full-mongodb.rst


### PR DESCRIPTION
- 3.4 driver compat: C, Cxx, Node, Java, Csharp
- 3.4 driver compat: perl
- 3.4 driver compat: php
- 3.4 driver compat: python
- 3.4 driver compat: motor
- 3.4 driver compat: ruby
- 3.4 driver compat: scala
- 3.4: driver compat cleanup

Staged: https://docs-mongodbcom-staging.corp.mongodb.com/allison/master/drivers/driver-compatibility-reference.html