### PR TITLE
Fix Perl driver compat matrix

### DIFF
--- a/source/drivers/perl.txt
+++ b/source/drivers/perl.txt
@@ -49,7 +49,7 @@ MongoDB Compatibility
      - |checkmark|
      - |checkmark|
      - |checkmark|
-     -
+     - |checkmark|
 
    * - 1.4.x
      - |checkmark|


### PR DESCRIPTION
Looks like the 3.4 checkmark for perl driver 1.6 was omitted.
