### PR TITLE
Updated older drivers for Elixir

### DIFF
--- a/source/drivers/community-supported-drivers.txt
+++ b/source/drivers/community-supported-drivers.txt
@@ -71,8 +71,11 @@ Community Supported Drivers Reference
 
 - Elixir
 
-  - `Elixir Driver <https://github.com/checkiz/elixir-mongo>`_ - MongoDB
+  - `Elixir Driver <https://github.com/ericmj/mongodb>`_ - MongoDB
     driver in Elixir, a functional language built on top of the Erlang VM.
+    
+  - `Ecto adapter <https://github.com/michalmuskala/mongodb_ecto>`_ - MongoDB adapter 
+    for Ecto, a database wrapper and language integrated query for Elixir.
 
 - Entity
 


### PR DESCRIPTION
## Reason 
Current documentation contains outdated drivers for the Elixir. 

## Description
Now the documentation includes new drivers for the Elixir
