### PR TITLE
PHPLIB-253: Clean up list of third-party PHP libraries

### DIFF
--- a/source/drivers/php-libraries.txt
+++ b/source/drivers/php-libraries.txt
@@ -9,391 +9,160 @@ PHP Libraries, Frameworks and Tools
 .. contents:: On this page
    :local:
    :backlinks: none
-   :depth: 1
+   :depth: 2
    :class: singlecol
 
-The PHP community has created a huge number of libraries to make working
-with MongoDB easier and integrate it with existing frameworks.
+Libraries for the ``mongodb`` Extension
+---------------------------------------
 
-Libraries and Frameworks
-------------------------
-
-CakePHP
-~~~~~~~
-
-- `MongoDB datasource for CakePHP <https://github.com/ichikaway/cakephp-mongodb>`_.
-
-- `Introductory blog post <http://mark-story.com/posts/view/using-mongodb-with-cakephp>`_
-  on using it with MongoDB.
-
-Doctrine
-~~~~~~~~
-
-`ODM <http://www.doctrine-project.org/projects/mongodb-odm.html>`_
-(Object Document Mapper) is an experimental Doctrine MongoDB object
-mapper. The ``Doctrine\ODM\Mongo`` namespace is an experimental project for
-a PHP 5.3 MongoDB Object Mapper. It allows you to easily write PHP 5
-classes and map them to collections in MongoDB. You just work with your
-objects like normal and Doctrine will transparently persist them to
-MongoDB.
-
-This project implements the same "style" of the Doctrine 2 ORM project
-interface so it will look very familiar to you and it has lots of the
-same features and implementations.
-
-- `MongoDB ODM Documentation <http://www.doctrine-project.org/projects/mongodb-odm.html>`_:
-  API, Reference, and Cookbook
-
-- `Official blog post <http://www.doctrine-project.org/blog/index.html>`_
-
-- `Screencast <http://www.screencast.com/users/jwage/folders/Default/media/d01858d5-f9f4-43e3-a3e1-669729a85fcc>`_
-
-- `Blog post on using with Symfony <http://blog.servergrove.com/2010/04/28/mongodb-with-php-and-symfony/>`_
-
-- `Bug tracker <http://www.doctrine-project.org/jira/browse/MODM>`_
-
-Drupal
-~~~~~~
-
-`MongoDB Integration <http://drupal.org/project/mongodb>`_:
-
-- Drupal 8.x (8.x-2.x branch): client services, a watchdog implementation (PSR/3 logging)
-- Drupal 7.x (7.x-1.x branch): connection, a watchdog implementation (logging), block, cache, field storage, lock, path, queue, session.
-
-`EFQ Views <https://www.drupal.org/project/efq_views>`_:
-
-- Drupal 7.x: , Views (query builder) backend, using field storage from the main project.
-
-Fat-Free Framework
-~~~~~~~~~~~~~~~~~~
-
-`Fat-Free <http://fatfreeframework.com/>`_ is a powerful yet
-lightweight PHP 5.3+ Web development framework designed to help you
-build dynamic and robust applications fast.
-
-Kohana Framework
-~~~~~~~~~~~~~~~~
-
-`Mango <https://github.com/Wouterrr/mangodb>`_: An
-ActiveRecord-like library for PHP, for the
-`Kohana <http://kohanaframework.org/>`_ PHP Framework.
-
-Lithium
-~~~~~~~
-
-`Lithium <http://li3.me/>`_ supports MongoDB out-of-the-box.
-
-Laravel Framework
-~~~~~~~~~~~~~~~~~
-
-- `Laravel MongoDB <https://github.com/jenssegers/laravel-mongodb>`_:
-  A model and query builder with support for MongoDB, using the
-  original Laravel API.
-
-- `laravel-mongo <https://github.com/lindelius/laravel-mongo>`_: 
-  A MongoDB Library for Laravel and its micro-framework version, Lumen.
-  Built on top of the official MongoDB PHP Library.
-
-Symfony 2
-~~~~~~~~~
-
-- `Symfony 2 Logger <http://code.google.com/p/mongodbloganalyzer/>`_: A
-  centralized logger for Symfony applications. See
-  `blog post on Symfony <http://obvioushints.blogspot.com/2009/07/my-guess-on-symfony-2.html>`_.
-
-Symfony 1
-~~~~~~~~~
-
-- `sfMongoSessionStorage <https://github.com/brtriver/sfMongoSessionStorage>`_:
-  Manages session storage via MongoDB with symfony.
-
-- `sfStoragePerformancePlugin <http://www.symfony-project.org/plugins/sfStoragePerformancePlugin>`_:
-  This plugin contains some extra storage engines (MongoDB and
-  Memcached) that are currently missing from the Symfony (>= 1.2) core.
-
-TechMVC
-~~~~~~~
-
-An extensive MVC 2 based PHP framework which supports MongoDB directly
-with only PHPMongo extension.
-
-- Hosted at <http://sourceforge.net/projects/techmvc/>
-
-- Demo example available at <http://demo.techmvc.techunits.com/>
-
-Thundergrid
-~~~~~~~~~~~
-
-`Thundergrid <https://github.com/Bioshox/Thundergrid>`_ is a
-:manual:`GridFS </applications/gridfs/>`
-framework for PHP. Thundergrid is a simple framework written in PHP that
-allows you to rapidly store files in your MongoDB database using the
-GridFS specification.
-
-Thundergrid gives you the ability to control exactly how you use GridFS
-in your scripts. It allows you to list, filter, and display objects
-within GridFS quickly and rapidly.
-
-Vork
-~~~~
-
-.. image:: /figures/php-libraries-frameworks-and-tools-vork.png
-
-`Vork <http://www.vork.us/>`_, the high-performance enterprise framework
-for PHP, natively supports MongoDB as either a primary datasource or used
-in conjunction with an RDBMS. Designed for scalability & Green-IT, Vork
-serves more traffic with fewer servers and can be configured to operate
-without any disk-IO.
-
-Vork provides a full MVC stack that outputs semantically-correct XHTML
-1.1, complies with Section 508 Accessibility guidelines & Zend-Framework
-coding-standards, has SEO-friendly URLs, employs CSS-reset for
-cross-browser display consistency and is written in well-documented
-object-oriented E_STRICT PHP5 code.
-
-An extensive set of tools are built into Vork for ecommerce
-(cc-processing, SSL, PayPal, AdSense, shipment tracking, QR-codes),
-Google Maps, translation & internationalization, Wiki, Amazon Web
-Services, Social-Networking (Twitter, Meetup, ShareThis, YouTube,
-Flickr) and much more.
-
-Webiny Framework
-~~~~~~~~~~~~~~~~
-
-`Webiny Framework <http://www.webiny.com/>`_ is an open source
-web development framework written in PHP 5.5. The `Entity Component
-<http://www.webiny.com/webiny-framework/php-entity-mongodb-odm/>`_ is a
-full-featured Object Document Wrapper for MongoDB. It provides simple
-creation and filtering of records on multiple collections.  In
-combination with the `Mongo Component
-<http://www.webiny.com/webiny-framework/php-mongodb/>`_ it provides
-seamless integration.
-
-You can download the library from our `GitHub
-<https://github.com/Webiny/Framework/>`_ or you can use ``composer``:
-
-.. code-block:: sh
-
-   composer require webiny/framework
-
-
-Yamop
-~~~~~
-
-This is yet another, open source, and very simple ODM for MongoDB. It
-works like the standard MongoDB PHP extension interface but returns
-objects instead of arrays (as ODM). Queries stay the same. Provides
-driver level "joins," that resolves related objects.
-
-See: `Yamop <https://github.com/mawelous/yamop>`_ and `Yamop for
-Laravel <https://github.com/mawelous/yamop-laravel>`_.
-
-Yii
-~~~
-
-`Yii MongoDB Driver <https://github.com/fromYukki/Yii-MongoDB-Driver>`_ is a Yii1 extension
-which plans on supporting Yii2.
-
-`mongoyii <http://github.com/Sammaye/MongoYii/>`_ is a lightweight
-ActiveRecord-like support for MongoDB in Yii.
-
-Yii2
-~~~~
-
-The `Yii2 Framework <https://github.com/yiisoft/yii2/>`_ includes a
-`MongoDB Extension <http://www.yiiframework.com/doc-2.0/ext-mongodb-index.html>`_.
-
-Zend Framework
-~~~~~~~~~~~~~~
-
-- `Shanty Mongo <https://github.com/coen-hyde/Shanty-Mongo>`_ is a
-  prototype MongoDB adapter for the Zend Framework. It's intention is to
-  make working with MongoDB documents as natural and as simple as
-  possible. In particular allowing embedded documents to also have
-  custom document classes.
-
-- `ZF Cache Backend for MongoDB <https://github.com/stunti/Stunti_Cache_Backend_Mongo>`_:
-  supports tags and auto-cleaning.
-
-Phalcon Framework
-~~~~~~~~~~~~~~~~~
-
-`Object-Document Mapper
-<http://docs.phalconphp.com/en/latest/reference/odm.html>`_ The ODM
-offers a CRUD functionality, events, validations among other
-services.
-
-Stand-Alone Tools
------------------
-
-Autocomplete for IDEs
+Stand-alone Libraries
 ~~~~~~~~~~~~~~~~~~~~~
 
-`PeclMongoPhpDoc <https://github.com/localgod/PeclMongoPhpDoc>`_ gives
-IDEs information about the Pecl extension to help with autocomplete and
-docs.
+- `Mongo Queue PHP <https://github.com/dominionenterprises/mongo-queue-php>`_ is
+  a PHP message queue, which uses MongoDB as a backend.
 
-ActiveMongo
-~~~~~~~~~~~
+- `Mongo PHP Adapter <https://github.com/alcaeus/mongo-php-adapter>`_ is a
+  userland library designed to act as an adapter between applications relying on
+  the legacy ``mongo`` extension and the new ``mongodb`` extension. It provides
+  the API of the legacy driver on top of the new driver and library, which
+  allows for compatibility with PHP 7.
 
-- `ActiveMongo <https://github.com/crodas/ActiveMongo>`_ is a
-  simple ActiveRecord for MongoDB in PHP.
+- `Mongodm <https://github.com/purekid/mongodm>`_ is a MongoDB ORM that includes
+  support for references, embedded documents, and multilevel inheritance.
 
-- There's an introduction to get you started at
-  <http://crodas.org/activemongo.php>.
+- `Yadm <https://github.com/makasim/yadm>`_ is a MongoDB ODM written for the
+  **mongodb** extension. It is schema-less and supports fast object hydration
+  and persistence, which makes it well-suited for modeling aggregation results.
 
-Comfi
-~~~~~
+Framework Integrations
+~~~~~~~~~~~~~~~~~~~~~~
 
-`Comfi <https://github.com/parf/Mongo-PHP-ORM>`_ is a MongoDB PHP ORM
-(part of Comfi.com Homebase Framework)
+- Drupal
 
-Mongofill
-~~~~~~~~~
+  - `MongoDB integration for Drupal <https://www.drupal.org/project/mongodb>`_.
+    This is a collection of several modules which allow sites to store different
+    types of Drupal data in MongoDB. Support for the ``mongodb`` extension
+    exists for Drupal 8.
 
-`Mongofill <https://github.com/mongofill/mongofill>`_ is a pure PHP
-implementation of the
-`mongo PECL extension <http://pecl.php.net/package/mongo>`_, which means that it
-can be used with HHVM. Additionally, the
-`mongofill-hhvm <https://github.com/mongofill/mogofill-hhvm>`_ package provides
-a `libbson <https://github.com/mongodb/libbson>`_ extension for HHVM for more
-performant BSON encoding and decoding.
+- Laravel
 
-Mongofilesystem
-~~~~~~~~~~~~~~~
+  - `Laravel MongoDB <https://github.com/jenssegers/laravel-mongodb>`_: An
+    Eloquent model and Query builder with support for MongoDB, using the
+    original Laravel API. This library extends the original Laravel classes, so
+    it uses exactly the same methods.
 
-`Mongofilesystem <https://github.com/harrydeluxe/mongofilesystem>`_ is
-a filesystem based on MongoDB
-:manual:`GridFS </applications/gridfs/>`.
-It will help you use MongoDB GridFS like a typical filesystem, using
-the familiar PHP commands.
+  - `laravel-mongo <https://github.com/lindelius/laravel-mongo>`_:  Convenience
+    library for working with MongoDB documents in Laravel and the Lumen
+    micro-framework. This library is built on top of the official MongoDB PHP
+    library and includes an abstract model, a helper class for handling bulk
+    writes, database wrappers for Laravel and Lumen, and some necessary helper
+    functions.
 
-Mandango
-~~~~~~~~
+- Webiny
 
-`Mandango <http://mandango.org/>`_ is a simple, powerful, ultrafast
-Object Document Mapper (ODM) for PHP and MongoDB.
+  - `Entity Component
+    <http://www.webiny.com/webiny-framework/php-entity-mongodb-odm/>`_ is an ODM
+    layer for MongoDB. Entity classes created using this component will serve as
+    the main building blocks for modules, forms, tables, etc.
 
-Mongator ODM
-~~~~~~~~~~~~
+  - `Mongo Component <http://www.webiny.com/webiny-framework/php-mongodb/>`_ is
+    an abstraction layer for MongoDB.
 
-`Mongator ODM <https://github.com/mongator/mongator/>`_  is an easy,
-powerful and ultrafast ODM for PHP and MongoDB. (forked from Mandango project)
-Up-to-date and mantained, currently used in production.
+- Yii2
 
-MongoDB Pagination
-~~~~~~~~~~~~~~~~~~
+  - `MongoDB Extension for Yii 2
+    <http://www.yiiframework.com/doc-2.0/ext-mongodb-index.html>`_ provides
+    MongoDB integration for Yii framework 2.0.
 
-PHP `MongoDB Pagination <http://sourceforge.net/projects/mongopagination/>`_
-is the pagination plugin for MongoDB released under MIT License.
-It is simple to install and use. It has been developed under TechMVC 3.0.4
-but is compatible with any 3rd party framework (e.g. Zend (tested)).
+Libraries for the ``mongo`` Extension
+-------------------------------------
 
-MongoDB PHP ODM
-~~~~~~~~~~~~~~~
+Stand-alone Libraries
+~~~~~~~~~~~~~~~~~~~~~
 
-`MongoDb PHP ODM <https://github.com/colinmollenhour/mongodb-php-odm>`_
-is a simple object wrapper for the MongoDB PHP driver
-classes which makes using MongoDB in your PHP application more like
-ORM, but without the suck. It is designed for use with Kohana 3 but
-will also integrate easily with any PHP application with almost no
-additional effort.
+- `Doctrine MongoDB ODM <https://github.com/doctrine/mongodb-odm>`_ is a library
+  that provides a PHP object mapping functionality for MongoDB. An underlying
+  `MongoDB abstraction layer <https://github.com/doctrine/mongodb>`_ exists as
+  a separate project. A `Symfony bundle
+  <https://github.com/doctrine/DoctrineMongoDBBundle>`_ and `Zend Framework
+  module <https://github.com/doctrine/DoctrineMongoODMModule>`_ for the ODM are
+  also available. Although it is written for the legacy ``mongo`` extension, it
+  is tested to work with the ``mongodb`` extension using `Mongo PHP Adapter
+  <https://github.com/alcaeus/mongo-php-adapter>`_.
 
-Mongo-Queue-PHP
-~~~~~~~~~~~~~~~
+- `Mongator ODM <https://github.com/mongator/mongator/>`_ is an easy, powerful,
+  and ultrafast ODM for PHP and MongoDB. It is a fork of the
+  `Mandango ODM <http://mandango.org/>`_.
 
-PHP message queue using MongoDB as a backend
+- `MongoFilesystem <https://github.com/AlexanderMitov/MongoFilesystem>`
+  implements a hierarchical file system using MongoDB as a storage engine. The
+  library uses GridFS for storing the files and a standard collection for the
+  folder information. There is an object-oriented representation of the folders
+  and files in the filesystem and rich API for performing operations. The
+  library also implements renderers for JSON, HTML, and XML.
 
-`Mongo-Queue-PHP page <https://github.com/dominionenterprises/mongo-queue-php>`_
+- `Mongofill <https://github.com/mongofill/mongofill>`_ is a pure PHP
+  implementation of the ``mongo`` extension, which means that it can be used
+  with HHVM. A separate `mongofill-hhvm
+  <https://github.com/mongofill/mongofill-hhvm>`_ package provides a `libbson
+  <https://github.com/mongodb/libbson>`_ extension for HHVM, which allows for
+  more performant BSON encoding and decoding.
 
-MongoQueue
-~~~~~~~~~~
+- `MongoQueue <https://github.com/lunaru/mongoqueue>`_ is a PHP queue that
+  allows for moving tasks and jobs into an asynchronous process for completion
+  in the background. The queue is managed by MongoDB.
 
-`MongoQueue <https://github.com/lunaru/mongoqueue>`_ is a PHP queue that
-allows for moving tasks and jobs into an asynchronous process for
-completion in the background. The queue is managed by MongoDB.
+- `MongoRecord <https://github.com/lunaru/mongorecord>`_ is a PHP MongoDB ORM
+  layer built on top of the ``mongo`` PECL extension.
 
-MongoQueue is an extraction from online classifieds site
-`Oodle <http://www.oodle.com/>`_. Oodle uses MongoQueue to background
-common tasks in order to keep page response times low.
+- `PHPMongo ODM <https://github.com/sokil/php-mongo>`_ is an ODM with support
+  for validation, relations, events, document versioning, and database
+  migrations. Although it is written for the legacy ``mongo`` extension, it is
+  tested to work with the ``mongodb`` extension using `Mongo PHP Adapter
+  <https://github.com/alcaeus/mongo-php-adapter>`_.
 
-MongoRecord
-~~~~~~~~~~~
+- `Yamop <https://github.com/mawelous/yamop>`_ is yet another MongoDB ODM for
+  PHP. It works like the standard MongoDB PHP extension interface but returns
+  objects instead of arrays (as ODM). A `Laravel component
+  <https://github.com/mawelous/yamop-laravel>`_ is also available.
 
-`MongoRecord <https://github.com/lunaru/mongorecord>`_ is a PHP MongoDB
-ORM layer built on top of the PHP MongoDB PECL extension.
+Framework Integrations
+~~~~~~~~~~~~~~~~~~~~~~
 
-MongoRecord is an extraction from online classifieds site
-`Oodle <http://www.oodle.com/>`_. Oodle’s requirements for a manageable,
-easy to understand interface for dealing with the super-scalable MongoDB
-datastore was the primary reason for MongoRecord. It was developed to
-use with PHP applications looking to add MongoDB’s scaling capabilities
-while dealing with a nice abstraction layer.
+- Drupal
 
-Morph
-~~~~~
+  - `MongoDB integration for Drupal <https://www.drupal.org/project/mongodb>`_.
+    This is a collection of several modules which allow sites to store different
+    types of Drupal data in MongoDB. Support for the ``mongo`` extension exists
+    for Drupal 6, 7, and 8.
 
-`Morph <https://github.com/a-musing-moose/morph>`_ at GitHub is a high-level
-PHP library for MongoDB. Morph comprises a suite of objects and object
-primitives that are designed to make working with MongoDB in PHP a
-breeze.
+- Kohana
 
-simplemongophp
-~~~~~~~~~~~~~~
+  - `MangoDB <https://github.com/Wouterrr/mangodb>`_: Mango is an ORM and
+    ActiveRecord-like library that takes full advantage of MongoDB's features.
 
-`simplemongophp <https://github.com/ibwhite/simplemongophp>`_ at
-GitHub is a simple layer for using data objects. See
-`blog post <https://groups.google.com/forum/?hl=en&fromgroups=#!topic/mongodb-user/_VHvXu7OIjg>`_.
+  - `MongoDB PHP ODM <https://github.com/colinmollenhour/mongodb-php-odm>`_ is a
+    simple but powerful set of wrappers for using MongoDB in PHP. It is designed
+    for use with Kohana 3 but should integrate easily with any PHP
+    application.
 
-Mongodm
-~~~~~~~
+- Phalcon
 
-`Mongodm <https://github.com/purekid/mongodm>`_ is a simple and
-flexible PHP MongoDB ORM that includes support for references (lazy
-loading,) and multilevel inheritance.
+  - `Object Document Mapper <https://docs.phalconphp.com/en/latest/reference/odm.html>`_
+    offers a CRUD functionality, events, validations, and other services for
+    MongoDB.
 
-kanon-mongo
-~~~~~~~~~~~
+- Yii 1.x
 
-`kanon-mongo <https://github.com/olamedia/kanon-mongo>`_ is a simple
-memory-safe PHP MongoDB ORM.
-Requirements: PHP >= 5.3, PECL mongoclient >= 1.3.0
+  - `MongoYii <http://github.com/Sammaye/MongoYii/>`_ is ActiveRecord ORM for
+    Yii framework 1.x that supports MongoDB.
 
-PHPMongo
-~~~~~~~~
+  - `Yii MongoDB Driver <https://github.com/fromYukki/Yii-MongoDB-Driver>`_ is a
+    MongoDB extension for Yii framework 1.x.
 
-`PHPMongo <https://github.com/sokil/php-mongo>`_ is a ODM with support
-of validating, relations, events and behaviors.
+Miscellaneous Projects
+~~~~~~~~~~~~~~~~~~~~~~
 
-MongoFilesystem
-~~~~~~~~~~~~~~~
-
-`MongoFilesystem <https://github.com/AlexanderMitov/MongoFilesystem>`
-is a filesystem implementation on top of MongoDB.  The library manages
-file/folder hierarchy by using GridFS and standard collections. It has
-a rich API and JSON/XML/HTML renderers as well.
-
-Yadm
-~~~~
-
-`Yadm <https://github.com/makasim/yadm>`_ is a MongoDB ODM based on the new
-**mongodb** extension. It is schema-less and supports fast object hydration and
-persistence.
-
-Blogs & HOWTOs
---------------
-
-How to batch import JSON data output from FFprobe for motion stream analysis
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-FFprobe is a stream analyzer that optionally reports in JSON. This
-example is a PHP script that reads JSON from STDIN, makes an object
-using json_decode, and inserts the object into a MongoDB database. This
-script could be used with any program that outputs a JSON stream. A bash
-script will be used to batch process all files within the current
-directory. For example, the data may be used for analysis and logging of
-a day's shoot.
-
-- `Batch import Multimedia Stream Data into MongoDB with FFprobe <http://www.waitman.net/ffprobe-mongodb-batch-import-json.html>`_
-
-- `Code and Sample Output <https://github.com/creamy/in-ffprobe-mongodb>`_ at GitHub
+- `PeclMongoPhpDoc <https://github.com/localgod/PeclMongoPhpDoc>`_ provides
+  skeleton classes for the ``mongo`` extension, which may be used to support
+  autocomplete and inline documentation for IDEs.


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPLIB-253

Remove links to unmaintained or inactive projects and generic frameworks. Any preserved projects are now grouped as either stand-alone libraries or framework integrations.

Related asset cleanup in https://github.com/mongodb/docs-assets/pull/21