### PR TITLE
Update amazon-ec2.txt - Update udev rules for EC2  

### DIFF
--- a/source/platforms/amazon-ec2.txt
+++ b/source/platforms/amazon-ec2.txt
@@ -228,7 +228,7 @@ command:
 
 .. code-block:: sh
 
-   echo 'ACTION=="add", KERNEL=="xvdf", ATTR{bdi/read_ahead_kb}="16"' | sudo tee -a /etc/udev/rules.d/85-ebs.rules
+   echo 'ACTION=="add|change", KERNEL=="xvdf", ATTR{bdi/read_ahead_kb}="16"' | sudo tee -a /etc/udev/rules.d/85-ebs.rules
 
 Once again, repeat the above command for all required volumes (note:
 the device we created was named :file:`/dev/xvdf` but the name used by


### PR DESCRIPTION
As reported by user and confirmed in my tests: 
On EC2 Centos7, this is the correct entry for the readahead. It is missing the "change" part:

ACTION=="add|change", KERNEL=="xvda", ATTR{bdi/read_ahead_kb}="16"