### PR TITLE
New entry for symfony in drivers/php-libraries.txt

### DIFF
--- a/source/drivers/php-libraries.txt
+++ b/source/drivers/php-libraries.txt
@@ -57,7 +57,14 @@ Framework Integrations
     library and includes an abstract model, a helper class for handling bulk
     writes, database wrappers for Laravel and Lumen, and some necessary helper
     functions.
+    
+- Symfony
 
+   - `MongoDB Bundle <https://github.com/facile-it/mongodb-bundle>`_: A simple 
+   bundle service integration of official mongodb/mongo-php-library. Allows you 
+   to configure direct/replicaSets connections to different databases or 
+   clusters and includes a convenient query profiler.
+   
 - Webiny
 
   - `Entity Component


### PR DESCRIPTION
Adds a dedicated symfony bundle to the list : drivers/php-libraries.txt
https://github.com/facile-it/mongodb-bundle