### PR TITLE
Update Perl compatibility tables

### DIFF
--- a/source/drivers/driver-compatibility-reference.txt
+++ b/source/drivers/driver-compatibility-reference.txt
@@ -632,23 +632,27 @@ MongoDB Compatibility
      - MongoDB 3.0
      - MongoDB 3.2
      - MongoDB 3.4
+     - MongoDB 3.6
 
    * - 1.8.x
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
 
    * - 1.6.x
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
 
    * - 1.4.x
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
      -
 
    * - 1.2.x
@@ -656,10 +660,12 @@ MongoDB Compatibility
      - |checkmark|
      - |checkmark|
      -
+     -
 
    * - 1.0.x
      - |checkmark|
      - |checkmark|
+     -
      -
      -
 

--- a/source/drivers/perl.txt
+++ b/source/drivers/perl.txt
@@ -40,6 +40,7 @@ MongoDB Compatibility
      - MongoDB 3.0
      - MongoDB 3.2
      - MongoDB 3.4
+     - MongoDB 3.6
 
    * - 1.8.x
      - |checkmark|
@@ -47,6 +48,7 @@ MongoDB Compatibility
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
 
 
    * - 1.6.x
@@ -55,12 +57,14 @@ MongoDB Compatibility
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
 
    * - 1.4.x
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
      -
 
    * - 1.2.x
@@ -69,11 +73,13 @@ MongoDB Compatibility
      - |checkmark|
      - |checkmark|
      -
+     -
 
    * - 1.0.x
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
      -
      -
 
@@ -98,8 +104,10 @@ Language Compatibility
      - 5.20
      - 5.22
      - 5.24
+     - 5.26
 
    * - 1.8.x
+     - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -118,6 +126,7 @@ Language Compatibility
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
 
    * - 1.4.x
      - |checkmark|
@@ -128,6 +137,7 @@ Language Compatibility
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
 
    * - 1.2.x
      - |checkmark|
@@ -138,6 +148,7 @@ Language Compatibility
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
 
    * - 1.0.x
      - |checkmark|
@@ -148,8 +159,7 @@ Language Compatibility
      - |checkmark|
      - |checkmark|
      - |checkmark|
-
-.. include:: /includes/extracts/perl-driver-compatibility-full-language.rst
+     -
 
 .. include:: /includes/unicode-checkmark.rst
 


### PR DESCRIPTION
This makes three changes:

* Shows that no available version of the driver is recommended for 3.6.

* Shows that only 1.8.x supports Perl 5.26

* Removes an extraneous link from the Perl page to the all-drivers
    compat page

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs-ecosystem/430)
<!-- Reviewable:end -->
