### PR TITLE
Update server and language compat tables

### DIFF
--- a/source/drivers/php.txt
+++ b/source/drivers/php.txt
@@ -17,7 +17,7 @@ For the official MongoDB PHP Driver reference, see:
 - `MongoDB PHP Library Documentation
   <https://docs.mongodb.com/php-library/>`_
 
-- `MongoDB PHP and HHVM Extension Documentation
+- `MongoDB PHP Extension Documentation
   <http://php.net/manual/en/set.mongodb.php>`_
 
 Drivers
@@ -59,6 +59,15 @@ MongoDB Compatibility
      - MongoDB 3.0
      - MongoDB 3.2
      - MongoDB 3.4
+     - MongoDB 3.6
+
+   * - PHPLIB 1.3 + mongodb-1.4
+     -
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
 
    * - PHPLIB 1.1 + mongodb-1.2
      - |checkmark|
@@ -66,12 +75,14 @@ MongoDB Compatibility
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
 
    * - PHPLIB 1.0 + mongodb-1.1
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
      -
 
    * - mongodb-1.1
@@ -80,11 +91,13 @@ MongoDB Compatibility
      - |checkmark|
      - |checkmark|
      -
+     -
 
    * - mongodb-1.0
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
      -
      -
 
@@ -94,13 +107,7 @@ MongoDB Compatibility
      - |checkmark|
      -
      -
-
-   * - mongo-1.5
-     - |checkmark|
-     - |checkmark|
      -
-     - 
-     - 
 
 .. include:: /includes/extracts/php-driver-compatibility-full-mongodb.rst
 
@@ -123,13 +130,20 @@ Language Compatibility
      - PHP 5.6
      - PHP 7.0
      - PHP 7.1
-     - HHVM 3.12
-     - HHVM 3.15
+     - PHP 7.2
+
+   * - mongodb-1.4
+     -
+     -
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
 
    * - mongodb-1.3
      -
-     - 
-     - |checkmark|
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -143,12 +157,10 @@ Language Compatibility
      - |checkmark|
      - |checkmark|
      - |checkmark|
-     - |checkmark|
-     - |checkmark|
+     -
 
    * - mongodb-1.1
      -
-     - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -163,7 +175,6 @@ Language Compatibility
      - |checkmark|
      - 
      - 
-     - |checkmark|
      -
 
    * - mongo-1.6
@@ -171,17 +182,6 @@ Language Compatibility
      - |checkmark|
      - |checkmark|
      - |checkmark|
-     - 
-     - 
-     - 
-     - 
-
-   * - mongo-1.5
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - 
      - 
      - 
      - 


### PR DESCRIPTION
Add MongoDB 3.6 and PHP 7.2 to compat tables, update tables for PHPC 1.4 and PHPLIB 1.3, and drop HHVM and mongo-1.5 from all tables.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs-ecosystem/431)
<!-- Reviewable:end -->
