### PR TITLE
Fix indentation for facile-it/mongodb-bundle and reword

### DIFF
--- a/source/drivers/php-libraries.txt
+++ b/source/drivers/php-libraries.txt
@@ -60,11 +60,11 @@ Framework Integrations
     
 - Symfony
 
-   - `MongoDB Bundle <https://github.com/facile-it/mongodb-bundle>`_: A
-     simple bundle service integration of official
-     mongodb/mongo-php-library. Allows you to configure
-     direct/replicaSets connections to different databases or clusters
-     and includes a convenient query profiler.
+  - `MongoDB Bundle <https://github.com/facile-it/mongodb-bundle>`_: A
+    simple bundle service integration for the official `PHP library
+    <https://github.com/mongodb/mongo-php-library>`_. Allows you to configure
+    connections to different databases or clusters and includes a convenient
+    query profiler.
    
 - Webiny
 


### PR DESCRIPTION
https://github.com/mongodb/docs-ecosystem/commit/9e3c3e4ac08666637efcbcca25c3ea4b8fa89e77 originally added this project with incorrect indentation. @kay-kim attempted to fix it in https://github.com/mongodb/docs-ecosystem/commit/187dae9bca66a2bbc34e21b11d64dcb82da7d6c3#diff-8fb17b84ed41ac74a7db675e4f9b8001R63 but that left the bullet entry in a blockquote (see: https://docs.mongodb.com/ecosystem/drivers/php-libraries/#framework-integrations).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs-ecosystem/433)
<!-- Reviewable:end -->
