### PR TITLE
Fixed compatibility for Casbah

### DIFF
--- a/source/drivers/community-supported-drivers.txt
+++ b/source/drivers/community-supported-drivers.txt
@@ -203,6 +203,10 @@ Community Supported Drivers Reference
 
   - `MongoMapper <https://github.com/mongomapper/mongomapper>`_
 
+- Scala
+
+  - `Reactive-Mongo <http://reactivemongo.org/>`_
+
 - Swift
 
   - `MongoKitten <https://github.com/OpenKitten/MongoKitten>`_, - MongoDB driver for Swift

--- a/source/drivers/driver-compatibility-reference.txt
+++ b/source/drivers/driver-compatibility-reference.txt
@@ -1687,8 +1687,8 @@ MongoDB Compatibility
    * - 3.1
      - |checkmark|
      - |checkmark|
-     - |checkmark|
-     - |checkmark|
+     - |checkmark| (partial_)
+     - |checkmark| (partial_)
 
    * - 3.0
      - |checkmark|
@@ -1707,6 +1707,10 @@ MongoDB Compatibility
      -
      -
      -
+
+.. _partial: 
+
+Note: The 3.1 driver does not support all MongoDB 3.2 / 3.4 features.
 
 .. include:: /includes/older-server-versions-unsupported.rst
 

--- a/source/drivers/scala.txt
+++ b/source/drivers/scala.txt
@@ -42,7 +42,6 @@ MongoDB Compatibility
    :class: compatibility
 
    * - Scala Driver
-     - MongoDB 2.4
      - MongoDB 2.6
      - MongoDB 3.0
      - MongoDB 3.2
@@ -50,7 +49,6 @@ MongoDB Compatibility
      - MongoDB 3.6
 
    * - 2.2
-     - 
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -62,11 +60,9 @@ MongoDB Compatibility
      - |checkmark|
      - |checkmark|
      - |checkmark|
-     - |checkmark|
      - 
 
    * - 2.0
-     - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -77,17 +73,14 @@ MongoDB Compatibility
      - |checkmark|
      - |checkmark|
      - |checkmark|
-     - |checkmark|
      - 
    * - 1.1
-     - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
      -
      - 
    * - 1.0
-     - |checkmark|
      - |checkmark|
      - |checkmark|
      -
@@ -174,25 +167,35 @@ MongoDB Compatibility
    * - 3.1
      - |checkmark|
      - |checkmark|
-     - |checkmark|
-     - |checkmark|
+     - |checkmark| (partial_)
+     - |checkmark| (partial_)
 
    * - 3.0
      - |checkmark|
      - |checkmark|
-     - |checkmark|
+     -
      -
 
    * - 2.8
      - |checkmark|
      - |checkmark|
+     -
+     -
+
+   * - 2.7
      - |checkmark|
      -
+     -
+     -
+
+.. _partial: 
+
+Note: The 3.1 driver does not support all MongoDB 3.2 / 3.4 features.
 
 .. include:: /includes/extracts/casbah-driver-compatibility-full-mongodb.rst
 
 .. include:: /includes/older-server-versions-unsupported.rst
-
+ 
 Language Compatibility
 ``````````````````````
 
@@ -230,67 +233,3 @@ Language Compatibility
 .. include:: /includes/extracts/casbah-driver-compatibility-full-language.rst
 
 .. include:: /includes/unicode-checkmark.rst
-
-Community
----------
-
-- `Reactive-Mongo <http://reactivemongo.org/>`_ a reactive driver that
-  allows you to design very scalable applications unleashing MongoDB
-  capabilities like streaming infinite live collections and files for
-  modern Realtime Web applications.
-
-  - `Repo <https://github.com/ReactiveMongo/ReactiveMongo>`__
-  - `Blog post <http://stephane.godbillon.com/2012/08/30/reactivemongo-for-casbah-unleashing-mongodb-streaming-capabilities-for-realtime-web>`_
-
-- `Tepkin <http://jeroenr.github.io/tepkin/>`_ a reactive driver built on top of Akka.io and Akka Streams that
-  has a powerful DSL to easily create MongoDB records. It allows you to design very scalable applications by 
-  asynchronously inserting and retrieving (infinite) streams of data with non-blocking backpressure directly into 
-  respectively out of MongoDB through Akka streams.
-
-  - `Repo <https://github.com/jeroenr/tepkin>`__
-  - `Code samples <https://github.com/jeroenr/tepkin/tree/master/examples/src/main/scala/com/github/jeroenr/tepkin/examples>`_
-
-- `Rogue: A Type-Safe Scala DSL <http://engineering.foursquare.com/2011/01/21/rogue-a-type-safe-scala-dsl-for-querying-mongodb/>`_
-  - Foursquare's DSL for querying MongoDB alongside Lift-MongoDB-Record.
-  - `Tutorial/Intro <http://engineering.foursquare.com/2011/01/21/rogue-a-type-safe-scala-dsl-for-querying-mongodb/>`_
-  - `Source/Downloads <https://github.com/foursquare/fsqio/tree/master/src/jvm/io/fsq/rogue>`_
-
-- `frontlets <https://github.com/riedelcastro/frontlets>`_ lightweight
-  typed wrappers around Scala maps, with strong mongo support and JSON
-  integration. Supports type-safe queries in spirit of the original
-  mongo collection interface, object graph traversal, immutable
-  objects among other features.
-
-- `Subset2 <https://github.com/osinka/subset2>`_ MongoDB document
-  parser combinators and builders for use with the Java driver.
-
-- `Hammersmith <https://github.com/bwmcadams/hammersmith>`_ is a
-  Scala-based, asynchronous Netty driver for MongoDB with type-class
-  based fast custom object encoding.
-
-- `Salat <https://github.com/novus/salat/>`_ is a simple serialization
-  library for case classes. Leverages MongoDB's DBObject
-  (which uses BSON underneath) as its target format. Salat is focused
-  on fostering a DWIM and intuitive usage pattern for the end-user's
-  benefit, without sacrificing run time performance.
-
-- `Blue Eyes <http://github.com/jdegoes/blueeyes>`_ is a lightweight
-  framework for building REST APIs with strong MongoDB integration
-  including a DSL and Mock MongoDB for testing.
-
-- `Lift Web Framework <http://liftweb.net/>`_ supports MongoDB through
-  `Lift-MongoDB <http://www.assembla.com/wiki/show/liftweb/MongoDB>`_
-  and object mapping via the
-  `Record <http://www.assembla.com/wiki/show/liftweb/Record>`_ back-end
-  implementation.
-
-- `Mssd (MongoDB Synchronous Scala Driver)
-  <http://www.webpageanalyse.com/dev/mssd>`_ is a synchronous Scala
-  driver which wraps the plain old java driver with a more elegant
-  scala friendly API. Mssd focuses on simplicity of use with not too
-  much magic involved.
-
-- `Mongolia <https://github.com/nilskp/mongolia>`_ is a type-safe Scala
-  DSL, based on the v2.+ Java driver. It enforces type-safety by implicitly
-  converting non-BSON values to BSON, fully configurable. It also bypasses
-  the Java drivers' UUID bug by storing UUIDs as type 4 Binary.


### PR DESCRIPTION
Removed the community section of Scala as it was out of date.
Removed MongoDB 2.4 from the Scala driver matrix.

DOCS-11359 DOCS-11352

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs-ecosystem/435)
<!-- Reviewable:end -->
