### PR TITLE
Use consistent labels for PHP server/language compat tables

### DIFF
--- a/source/drivers/php.txt
+++ b/source/drivers/php.txt
@@ -71,7 +71,7 @@ Language Compatibility
      - PHP 7.1
      - PHP 7.2
 
-   * - mongodb-1.4
+   * - PHPLIB 1.3 + mongodb-1.4
      -
      -
      - |checkmark|
@@ -80,7 +80,7 @@ Language Compatibility
      - |checkmark|
      - |checkmark|
 
-   * - mongodb-1.3
+   * - PHPLIB 1.2 + mongodb-1.3
      -
      -
      - |checkmark|
@@ -89,7 +89,7 @@ Language Compatibility
      - |checkmark|
      - |checkmark|
 
-   * - mongodb-1.2
+   * - PHPLIB 1.1 + mongodb-1.2
      -
      - |checkmark|
      - |checkmark|
@@ -98,7 +98,7 @@ Language Compatibility
      - |checkmark|
      -
 
-   * - mongodb-1.1
+   * - PHPLIB 1.0 + mongodb-1.1
      -
      - |checkmark|
      - |checkmark|

--- a/source/includes/extracts-driver-compatibility-matrix.yaml
+++ b/source/includes/extracts-driver-compatibility-matrix.yaml
@@ -196,6 +196,8 @@ post: |
    In the table below, `mongodb <https://pecl.php.net/package/mongodb>`_ and
    `mongo <https://pecl.php.net/package/mongo>`_ refer to the new and legacy
    {{driver}}, respectively.
+   `PHPLIB <https://github.com/mongodb/mongo-php-library>`_ refers to the
+   userland library.
 ---
 ref: php-driver-compatibility-full-mongodb
 inherit:


### PR DESCRIPTION
We recently had a question from a support associate about PHPLIB language compatibility. This should address that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs-ecosystem/441)
<!-- Reviewable:end -->
