### PR TITLE
Update Perl ecosystem docs for v2.0 release supporting MongoDB v4.0

### DIFF
--- a/source/drivers/driver-compatibility-reference.txt
+++ b/source/drivers/driver-compatibility-reference.txt
@@ -670,12 +670,22 @@ MongoDB Compatibility
      - MongoDB 3.2
      - MongoDB 3.4
      - MongoDB 3.6
+     - MongoDB 4.0
+
+   * - 2.0.x
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
 
    * - 1.8.x
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
      -
 
    * - 1.6.x
@@ -684,11 +694,13 @@ MongoDB Compatibility
      - |checkmark|
      - |checkmark|
      -
+     -
 
    * - 1.4.x
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
      -
      -
 
@@ -698,10 +710,12 @@ MongoDB Compatibility
      - |checkmark|
      -
      -
+     -
 
    * - 1.0.x
      - |checkmark|
      - |checkmark|
+     -
      -
      -
      -

--- a/source/drivers/perl.txt
+++ b/source/drivers/perl.txt
@@ -41,6 +41,16 @@ MongoDB Compatibility
      - MongoDB 3.2
      - MongoDB 3.4
      - MongoDB 3.6
+     - MongoDB 4.0
+
+   * - 2.0.x
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
 
    * - 1.8.x
      - |checkmark|
@@ -48,6 +58,7 @@ MongoDB Compatibility
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
      -
 
 
@@ -58,12 +69,14 @@ MongoDB Compatibility
      - |checkmark|
      - |checkmark|
      -
+     -
 
    * - 1.4.x
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
      -
      -
 
@@ -74,11 +87,13 @@ MongoDB Compatibility
      - |checkmark|
      -
      -
+     -
 
    * - 1.0.x
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
      -
      -
      -
@@ -88,78 +103,7 @@ MongoDB Compatibility
 Language Compatibility
 ~~~~~~~~~~~~~~~~~~~~~~
 
-.. include:: /includes/extracts/perl-driver-compatibility-matrix-language.rst
-
-.. list-table::
-   :header-rows: 1
-   :stub-columns: 1
-   :class: compatibility-large
-
-   * - Perl Driver Version
-     - 5.10
-     - 5.12
-     - 5.14
-     - 5.16
-     - 5.18
-     - 5.20
-     - 5.22
-     - 5.24
-     - 5.26
-
-   * - 1.8.x
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-
-   * - 1.6.x
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     -
-
-   * - 1.4.x
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     -
-
-   * - 1.2.x
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     -
-
-   * - 1.0.x
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     -
+The MongoDB Perl driver requires Perl 5.10.1 or later.
 
 .. include:: /includes/unicode-checkmark.rst
 
@@ -223,11 +167,15 @@ would the MongoDB driver directly. Created by Ido Perlmuter.
 Other Perl Tools
 ----------------
 
-BSON
-~~~~
+BSON and BSON::XS
+~~~~~~~~~~~~~~~~~
 
 `BSON <https://metacpan.org/module/BSON>`_ is a pure-Perl BSON
-implementation. Created by Stefan G.
+implementation. Created by Stefan G. and maintained by MongoDB.
+
+`BSON::XS <https://metacpan.org/module/BSON::XS>`_ is an optional,
+XS-optimized BSON implementation plugin for the BSON module.  Created
+by MongoDB.
 
 Entities::Backend::MongoDB
 ~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Hold until June 27 when ecosystem pages are updated.
