### PR TITLE
Update server compat tables for C and PHP

### DIFF
--- a/source/drivers/driver-compatibility-reference.txt
+++ b/source/drivers/driver-compatibility-reference.txt
@@ -43,7 +43,7 @@ MongoDB Compatibility
      - |checkmark|
      - |checkmark|
      - |checkmark|
-     - |checkmark|
+     -
 
    * - Version 1.10
      - 
@@ -51,7 +51,7 @@ MongoDB Compatibility
      - |checkmark|
      - |checkmark|
      - |checkmark|
-     - |checkmark|
+     -
 
    * - Version 1.9
      - 

--- a/source/includes/php-mongodb-compatibility-table.rst
+++ b/source/includes/php-mongodb-compatibility-table.rst
@@ -17,7 +17,7 @@
      - |checkmark|
      - |checkmark|
      - |checkmark|
-     - |checkmark|
+     -
 
    * - PHPLIB 1.3 + mongodb-1.4
      -


### PR DESCRIPTION
libmongoc dropped support for 2.6 in 1.10 (CDRIVER-2510), which is included in PHPC 1.5.

See: https://jira.mongodb.org/browse/CDRIVER-2510

/cc @derickr @ajdavis 