### PR TITLE
(DOCSP-3269) add quotes to python keys

### DIFF
--- a/source/use-cases/storing-log-data.txt
+++ b/source/use-cases/storing-log-data.txt
@@ -204,12 +204,12 @@ using PyMongo, with an event from the Apache Log:
    >>> conn = pymongo.MongoClient()
    >>> db = conn.event_db
    >>> event = {
-   ...     _id: bson.ObjectId(),
-   ...     host: "127.0.0.1",
-   ...     time:  datetime(2000,10,10,20,55,36),
-   ...     path: "/apache_pb.gif",
-   ...     referer: "[http://www.example.com/start.html](http://www.example.com/start.html)",
-   ...     user_agent: "Mozilla/4.08 [en] (Win98; I ;Nav)"
+   ...     '_id': bson.ObjectId(),
+   ...     'host': "127.0.0.1",
+   ...     'time':  datetime(2000,10,10,20,55,36),
+   ...     'path': "/apache_pb.gif",
+   ...     'referer': "[http://www.example.com/start.html](http://www.example.com/start.html)",
+   ...     'user_agent': "Mozilla/4.08 [en] (Win98; I ;Nav)"
    ...}
 
 The following command will insert the ``event`` object into the


### PR DESCRIPTION
Staging link: https://docs-mongodbcom-staging.corp.mongodb.com/ecosystem/danielborowski/DOCSP-3269/use-cases/storing-log-data.html