### PR TITLE
Remove PHP 5.4 and add 7.3 in compat table

### DIFF
--- a/source/drivers/php.txt
+++ b/source/drivers/php.txt
@@ -63,15 +63,15 @@ Language Compatibility
    :class: compatibility-large
 
    * - PHP Driver
-     - PHP 5.4
      - PHP 5.5
      - PHP 5.6
      - PHP 7.0
      - PHP 7.1
      - PHP 7.2
+     - PHP 7.3
 
    * - mongodb-1.5
-     -
+     - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -79,21 +79,20 @@ Language Compatibility
      - |checkmark|
 
    * - mongodb-1.4
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
      -
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-
 
    * - mongodb-1.3
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
      -
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
 
 .. include:: /includes/extracts/php-driver-compatibility-full-language.rst
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHPC-1175

PHP 7.3 was recently released. Driver version 1.5.0+ is compatible. I've also removed PHP 5.4 since none of the listed driver versions support it, and 5.4 itself is very much end-of-life.