### PR TITLE
Add PHP 7.3 to language compat table

### DIFF
--- a/source/drivers/driver-compatibility-reference.txt
+++ b/source/drivers/driver-compatibility-reference.txt
@@ -901,9 +901,11 @@ Language Compatibility
      - PHP 7.0
      - PHP 7.1
      - PHP 7.2
+     - PHP 7.3
 
    * - mongodb-1.5
      -
+     - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -917,6 +919,7 @@ Language Compatibility
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
 
 
    * - mongodb-1.3
@@ -926,6 +929,7 @@ Language Compatibility
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
 
    * - mongodb-1.2
      - |checkmark|
@@ -933,6 +937,7 @@ Language Compatibility
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
      -
 
    * - mongodb-1.1
@@ -942,11 +947,13 @@ Language Compatibility
      - |checkmark|
      - |checkmark|
      -
+     -
 
    * - mongodb-1.0
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
      -
      -
      -


### PR DESCRIPTION
This is related to https://github.com/mongodb/docs-ecosystem/pull/474.

What whatever reason, we have different compatibility tables on the PHP-specific and cross-language pages. Here, I've left PHP 5.4 in place since it's still relevant to old driver versions present in this table.