### PR TITLE
Update post blocks for PHP server and language compat tables

### DIFF
--- a/source/includes/extracts-driver-compatibility-matrix.yaml
+++ b/source/includes/extracts-driver-compatibility-matrix.yaml
@@ -180,7 +180,7 @@ replacement:
   driver: MongoDB PHP driver
 post: |
    In the table below, `mongodb <https://pecl.php.net/package/mongodb>`_ and
-   and `PHPLIB <https://github.com/mongodb/mongo-php-library>`_ refer to the
+   `PHPLIB <https://github.com/mongodb/mongo-php-library>`_ refer to the
    {{driver}} and userland library, respectively.
 ---
 ref: php-driver-compatibility-matrix-language

--- a/source/includes/extracts-driver-compatibility-matrix.yaml
+++ b/source/includes/extracts-driver-compatibility-matrix.yaml
@@ -180,10 +180,8 @@ replacement:
   driver: MongoDB PHP driver
 post: |
    In the table below, `mongodb <https://pecl.php.net/package/mongodb>`_ and
-   `mongo <https://pecl.php.net/package/mongo>`_ refer to the new and legacy
-   {{driver}}, respectively.
-   `PHPLIB <https://github.com/mongodb/mongo-php-library>`_ refers to the
-   userland library.
+   and `PHPLIB <https://github.com/mongodb/mongo-php-library>`_ refer to the
+   {{driver}} and userland library, respectively.
 ---
 ref: php-driver-compatibility-matrix-language
 inherit:
@@ -193,11 +191,8 @@ replacement:
   driver: MongoDB PHP driver
   language: PHP
 post: |
-   In the table below, `mongodb <https://pecl.php.net/package/mongodb>`_ and
-   `mongo <https://pecl.php.net/package/mongo>`_ refer to the new and legacy
-   {{driver}}, respectively.
-   `PHPLIB <https://github.com/mongodb/mongo-php-library>`_ refers to the
-   userland library.
+   In the table below, `mongodb <https://pecl.php.net/package/mongodb>`_
+   refers to the {{driver}}.
 ---
 ref: php-driver-compatibility-full-mongodb
 inherit:


### PR DESCRIPTION
The legacy mongo extension is not present in either of these tables and can be removed. The userland library isn't present in the language compat table and can be removed.