### PR TITLE
DOCSP-5402 DOCSP-4584 Apply template to Go driver landing page

### DIFF
--- a/source/drivers/driver-compatibility-reference.txt
+++ b/source/drivers/driver-compatibility-reference.txt
@@ -264,6 +264,25 @@ Language Compatibility
      -
      -
 
+.. _reference-compatibility-go:
+
+Go Driver Compatibility
+-----------------------
+
+.. _reference-compatibility-mongodb-go:
+
+MongoDB Compatibility
+~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/mongodb-compatibility-table-go.rst
+
+.. _reference-compatibility-language-go:
+
+Language Compatibility
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/language-compatibility-table-go.rst
+
 .. _reference-compatibility-java:
 
 Java Driver Compatibility

--- a/source/drivers/go.txt
+++ b/source/drivers/go.txt
@@ -1,6 +1,8 @@
-========================
+.. include:: /includes/unicode-checkmark.rst
+
+=================
 MongoDB Go Driver
-========================
+=================
 
 .. default-domain:: mongodb
 
@@ -10,10 +12,60 @@ MongoDB Go Driver
    :depth: 1
    :class: twocols
 
-The official Go Driver is available on `github <https://github.com/mongodb/mongo-go-driver/>`_. See the `README <https://github.com/mongodb/mongo-go-driver/blob/master/README.md>`_ for more details on installation and bugs/feature reporting.
+Introduction
+------------
 
-MongoDB Go Driver Compatibility
----------------------------------
+This is the official MongoDB Go Driver.
+
+- `General documentation for the MongoDB Go Driver <https://godoc.org/github.com/mongodb/mongo-go-driver/mongo>`__
+
+- `Get Started with Go <https://www.mongodb.com/blog/post/mongodb-go-driver-tutorial>`_
+
+- `Migration from Community Drivers <https://www.mongodb.com/blog/post/go-migration-guide>`_
+
+- `Changelog <https://github.com/mongodb/mongo-go-driver/releases>`__
+
+- `Source Code <https://github.com/mongodb/mongo-go-driver>`__
+
+
+Installation
+------------
+
+The recommended way to get started using the MongoDB Go driver is by using ``dep`` 
+to install the dependency in your project:
+
+.. code-block:: go
+
+   dep ensure -add "go.mongodb.org/mongo-driver/mongo@~1.0.0"
+
+
+See `Installation <https://github.com/mongodb/mongo-go-driver#installation>`__
+
+
+Connect to MongoDB Atlas
+------------------------
+
+To connect to a `MongoDB Atlas <https://docs.atlas.mongodb.com/>`_ cluster, use the `Atlas connection string <https://docs.atlas.mongodb.com/driver-connection>`__ for your cluster:
+
+.. code-block:: go
+
+   import "go.mongodb.org/mongo-driver/mongo"
+
+   ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+   client, err := mongo.Connect(ctx, options.Client().ApplyURI(
+      "mongodb+srv://<username>:<password>@<cluster-address>/test"
+   ))
+   if err != nil { log.Fatal(err) }
+
+See `Usage <https://github.com/mongodb/mongo-go-driver#usage>`__
+for more detail.
+
+
+Compatibility
+-------------
+
+MongoDB Compatibility
+~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
    :header-rows: 1
@@ -42,26 +94,14 @@ Language Compatibility
 
 The MongoDB Go driver requires Go 1.10 or later.
 
-.. include:: /includes/unicode-checkmark.rst
+How to get help
+---------------
 
-Go Driver Documentation
------------------------
+- Join our `Google Group <https://groups.google.com/forum/#!forum/mongodb-go-driver>`__.
+- Ask on `Stack Overflow <https://stackoverflow.com/questions/tagged/mongo-go>`__.
+- Visit our `Support Channels <https://docs.mongodb.com/manual/support/>`__.
+- See the `project JIRA <https://jira.mongodb.org/browse/GODRIVER>`__ to raise issues or request features.
 
-On the GoDoc site:
-  - `General documentation for the MongoDB Go Driver <https://godoc.org/github.com/mongodb/mongo-go-driver/mongo>`_
-  - `BSON library documentation <https://godoc.org/github.com/mongodb/mongo-go-driver/bson>`_
-  
-MongoDB Blog Posts:
-  - `Get Started With Go <https://www.mongodb.com/blog/post/mongodb-go-driver-tutorial>`_
-  - `Migration From Community Drivers <https://www.mongodb.com/blog/post/go-migration-guide>`_
 
-Go Driver Community
--------------------
 
-Questions can be asked through the `mongo-go-driver Google Group <https://groups.google.com/forum/#!forum/mongodb-go-driver>`_
-
-Bug Reporting
--------------
-
-New Features and bugs can be reported on `jira <https://jira.mongodb.org/browse/GODRIVER>`_
 

--- a/source/drivers/go.txt
+++ b/source/drivers/go.txt
@@ -67,32 +67,12 @@ Compatibility
 MongoDB Compatibility
 ~~~~~~~~~~~~~~~~~~~~~
 
-.. list-table::
-   :header-rows: 1
-   :stub-columns: 1
-   :class: compatibility-large
-
-   * - Go Driver
-     - MongoDB 4.0
-     - MongoDB 3.6
-     - MongoDB 3.4
-     - MongoDB 3.2
-     - MongoDB 3.0
-     - MongoDB 2.6
-
-   * - 1.0.0
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-
+.. include:: /includes/mongodb-compatibility-table-go.rst
 
 Language Compatibility
 ~~~~~~~~~~~~~~~~~~~~~~
 
-The MongoDB Go driver requires Go 1.10 or later.
+.. include:: /includes/language-compatibility-table-go.rst
 
 How to get help
 ---------------

--- a/source/includes/language-compatibility-table-go.rst
+++ b/source/includes/language-compatibility-table-go.rst
@@ -1,0 +1,1 @@
+The MongoDB Go driver requires Go 1.10 or later.

--- a/source/includes/mongodb-compatibility-table-go.rst
+++ b/source/includes/mongodb-compatibility-table-go.rst
@@ -1,0 +1,20 @@
+.. list-table::
+   :header-rows: 1
+   :stub-columns: 1
+   :class: compatibility-large
+
+   * - Go Driver
+     - MongoDB 4.0
+     - MongoDB 3.6
+     - MongoDB 3.4
+     - MongoDB 3.2
+     - MongoDB 3.0
+     - MongoDB 2.6
+
+   * - 1.0.0
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|


### PR DESCRIPTION
This also adds a connection example for Atlas.

### JIRA
https://jira.mongodb.org/browse/DOCSP-4584
https://jira.mongodb.org/browse/DOCSP-5402

### Staged

https://docs-mongodbcom-staging.corp.mongodb.com/ecosystem/bush/go-driver-landing/drivers/go.html

