### PR TITLE
Removed duplicate statement in example code

### DIFF
--- a/source/drivers/motor.txt
+++ b/source/drivers/motor.txt
@@ -56,7 +56,7 @@ To connect to a `MongoDB Atlas <https://docs.atlas.mongodb.com/>`_ cluster, use 
 
    import motor
 
-   client = client = motor.motor_tornado.MotorClient(
+   client = motor.motor_tornado.MotorClient(
       "mongodb+srv://<username>:<password>@<cluster-url>/test?retryWrites=true&w=majority")
    db = client.test
 


### PR DESCRIPTION
`client = client = ` does not make that much sense :thinking:
Changed
```py
client = client = motor.motor_tornado.MotorClient(
```
to
```py
client = motor.motor_tornado.MotorClient(
```