### PR TITLE
DOCS-12826 Fix perl connect to Atlas snippet

### DIFF
--- a/source/drivers/perl.txt
+++ b/source/drivers/perl.txt
@@ -56,7 +56,7 @@ To connect to a `MongoDB Atlas <https://docs.atlas.mongodb.com/>`_ cluster, use 
    use MongoDB;
 
    my $client = MongoDB->connect(
-      "mongodb+srv://<username>:<password>@<cluster-address>/test?retryWrites=true&w=majority"
+     'mongodb+srv://<username>:<password>@<cluster-address>/test?retryWrites=true&w=majority'
    );
    my $db = $client->get_database( 'test' );
 


### PR DESCRIPTION
This page inherited a bug from the Atlas console connection snippet.
This uses single quotes in the snippet so as not to interpolate
a variable.

## Staged

https://docs-mongodbcom-staging.corp.mongodb.com/ecosystem/bush/docs-12826-perl-snippet-fix/drivers/perl.html#connect-to-mongodb-atlas
