### PR TITLE
DOCS-12791 Add Ruby 2.7 and 2.8 to compatibility table

### DIFF
--- a/source/drivers/driver-compatibility-reference.txt
+++ b/source/drivers/driver-compatibility-reference.txt
@@ -266,7 +266,7 @@ MongoDB Compatibility
 .. list-table::
    :header-rows: 1
    :stub-columns: 1
-   :class: compatibility-large
+   :class: compatibility-large no-padding
 
    * - Ruby Driver
      - MongoDB 4.0
@@ -275,6 +275,34 @@ MongoDB Compatibility
      - MongoDB 3.2
      - MongoDB 3.0
      - MongoDB 2.6
+     - MongoDB 2.4
+
+   * - 2.9
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     -
+
+   * - 2.8
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     -
+
+   * - 2.7
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     -
 
    * - 2.6
      - |checkmark|
@@ -283,18 +311,21 @@ MongoDB Compatibility
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
 
    * - 2.5
-     - 
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
 
    * - 2.4
      -
-     - 
+     -
+     - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -303,7 +334,8 @@ MongoDB Compatibility
    * - 2.3
      -
      -
-     - 
+     -
+     - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -311,16 +343,9 @@ MongoDB Compatibility
    * - 2.2
      -
      -
-     - 
+     -
      - |checkmark|
      - |checkmark|
-     - |checkmark|
-
-   * - 2.1
-     -
-     -
-     -
-     - 
      - |checkmark|
      - |checkmark|
 
@@ -328,7 +353,8 @@ MongoDB Compatibility
      -
      -
      -
-     - 
+     -
+     - |checkmark|
      - |checkmark|
      - |checkmark|
 
@@ -336,7 +362,8 @@ MongoDB Compatibility
      -
      -
      -
-     - 
+     -
+     - |checkmark|
      - |checkmark|
      - |checkmark|
 
@@ -345,7 +372,8 @@ MongoDB Compatibility
      -
      -
      -
-     - 
+     -
+     - |checkmark|
      - |checkmark|
 
    * - 1.10
@@ -353,89 +381,203 @@ MongoDB Compatibility
      -
      -
      -
-     - 
+     -
+     - |checkmark|
      - |checkmark|
 
+   * - 1.9
+     -
+     -
+     -
+     -
+     -
+     -
+     - |checkmark|
+
+   * - 1.8
+     -
+     -
+     -
+     -
+     -
+     -
+     - |checkmark|
 
 .. include:: /includes/older-server-versions-unsupported.rst
 
 .. _reference-compatibility-language-ruby:
 
-Language Compatibility
-~~~~~~~~~~~~~~~~~~~~~~
+Ruby Compatibility
+~~~~~~~~~~~~~~~~~~
 
 .. include:: /includes/extracts/ruby-driver-compatibility-matrix-language.rst
 
 .. list-table::
    :header-rows: 1
    :stub-columns: 1
-   :class: compatibility-large
+   :class: compatibility-large no-padding
 
    * - Ruby Driver
-     - Ruby 1.8.7
-     - Ruby 1.9
-     - Ruby 2.0
-     - Ruby 2.1
-     - Ruby 2.2
+     - Ruby 2.6
+     - Ruby 2.5
+     - Ruby 2.4
      - Ruby 2.3
+     - Ruby 2.2
+     - Ruby 2.1
+     - Ruby 2.0
+     - Ruby 1.9
+     - Ruby 1.8.7
+     - JRuby 9.2
+     - JRuby 9.1
      - JRuby
 
-   * - 2.6
+   * - 2.9
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
      -
      - |checkmark|
      - |checkmark|
+     -
+
+   * - 2.8
      - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     -
+     - |checkmark|
+     - |checkmark|
+     -
+
+   * - 2.7
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     -
+     - |checkmark|
+     - |checkmark|
+     -
+
+   * - 2.6
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     -
      - |checkmark|
      - |checkmark|
      -
 
    * - 2.5
      -
+     -
+     - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
      -
+     -
+     -
+     - |checkmark|
 
    * - 2.4
      -
+     -
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
+     -
+     -
      - |checkmark|
 
    * - 2.3
      -
+     -
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
+     -
+     -
      - |checkmark|
 
    * - 2.2
      -
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
-
-   * - 2.1
+     -
      -
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     - |checkmark|
+     -
+     -
+     -
+     - |checkmark|
+
+   * - 2.1
+     -
+     -
+     -
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     -
+     -
      -
      - |checkmark|
 
    * - 2.0
      -
+     -
+     -
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     -
+     -
+     -
+     - |checkmark|
+
+   * - 1.12 - 1.9
+     -
+     -
+     -
+     -
+     -
+     - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -443,9 +585,28 @@ Language Compatibility
      -
      - |checkmark|
 
-   * - 1.9 - 1.12
+   * - 1.8
+     -
+     -
+     -
+     -
+     -
+     -
      - |checkmark|
      - |checkmark|
+     - |checkmark|
+     -
+     -
+     - |checkmark|
+
+   * - 1.7 - 1.6
+     -
+     -
+     -
+     -
+     -
+     -
+     -
      - |checkmark|
      - |checkmark|
      -


### PR DESCRIPTION
Tables copied from https://docs.mongodb.com/ruby-driver/current/reference/driver-compatibility/

## Staged
https://docs-mongodbcom-staging.corp.mongodb.com/ecosystem/bush/docs-12791-ruby-version-table/drivers/driver-compatibility-reference.html#ruby-driver-compatibility
