### PR TITLE
DOCSP-5987 Add 4.2 feature availability table

### DIFF
--- a/source/drivers/csharp.txt
+++ b/source/drivers/csharp.txt
@@ -66,8 +66,6 @@ Compatibility
 MongoDB Compatibility
 ~~~~~~~~~~~~~~~~~~~~~
 
-.. include:: /includes/extracts/csharp-driver-compatibility-matrix-mongodb.rst
-
 .. include:: /includes/mongodb-compatibility-table-csharp.rst
 
 Language Compatibility

--- a/source/drivers/driver-compatibility-reference.txt
+++ b/source/drivers/driver-compatibility-reference.txt
@@ -72,8 +72,6 @@ C#/.Net Driver Compatibility
 MongoDB Compatibility
 ~~~~~~~~~~~~~~~~~~~~~
 
-.. include:: /includes/extracts/csharp-driver-compatibility-matrix-mongodb.rst
-
 .. include:: /includes/mongodb-compatibility-table-csharp.rst
 
 .. _reference-compatibility-language-csharp:
@@ -114,8 +112,6 @@ Java Driver Compatibility
 MongoDB Compatibility
 ~~~~~~~~~~~~~~~~~~~~~
 
-.. include:: /includes/extracts/java-driver-compatibility-matrix-mongodb.rst
-
 .. include:: /includes/mongodb-compatibility-table-java.rst
 
 .. include:: /includes/older-server-versions-unsupported.rst
@@ -143,8 +139,6 @@ Node.js Driver Compatibility
 
 MongoDB Compatibility
 ~~~~~~~~~~~~~~~~~~~~~
-
-.. include:: /includes/extracts/node-driver-compatibility-matrix-mongodb.rst
 
 .. include:: /includes/mongodb-compatibility-table-node.rst
 
@@ -210,8 +204,6 @@ Python Driver Compatibility
 
 MongoDB Compatibility
 ~~~~~~~~~~~~~~~~~~~~~
-
-.. include:: /includes/extracts/cpp-driver-compatibility-matrix-mongodb.rst
 
 .. include:: /includes/mongodb-compatibility-table-python.rst
 

--- a/source/drivers/java.txt
+++ b/source/drivers/java.txt
@@ -86,8 +86,6 @@ Compatibility
 MongoDB Compatibility
 ~~~~~~~~~~~~~~~~~~~~~
 
-.. include:: /includes/extracts/java-driver-compatibility-matrix-mongodb.rst
-
 .. include:: /includes/mongodb-compatibility-table-java.rst
 
 .. include:: /includes/older-server-versions-unsupported.rst

--- a/source/drivers/node.txt
+++ b/source/drivers/node.txt
@@ -88,8 +88,6 @@ Compatibility
 MongoDB Compatibility
 ~~~~~~~~~~~~~~~~~~~~~
 
-.. include:: /includes/extracts/node-driver-compatibility-matrix-mongodb.rst
-
 .. include:: /includes/mongodb-compatibility-table-node.rst
 
 .. include:: /includes/older-server-versions-unsupported.rst

--- a/source/drivers/pymongo.txt
+++ b/source/drivers/pymongo.txt
@@ -86,8 +86,6 @@ Compatibility
 MongoDB Compatibility
 ~~~~~~~~~~~~~~~~~~~~~
 
-.. include:: /includes/extracts/python-driver-compatibility-matrix-mongodb.rst
-
 .. include:: /includes/mongodb-compatibility-table-python.rst
 
 .. include:: /includes/older-server-versions-unsupported.rst

--- a/source/includes/mongodb-compatibility-table-csharp.rst
+++ b/source/includes/mongodb-compatibility-table-csharp.rst
@@ -1,3 +1,45 @@
+.. note:: MongoDB 4.2 Feature Availability
+
+   The following table specifies which key MongoDB 4.2 features are available in
+   `the latest release <https://github.com/mongodb/mongo-csharp-driver/releases/tag/v2.9.0-beta2>`__
+   of the driver:
+
+.. list-table::
+   :header-rows: 1
+   :stub-columns: 1
+   :class: compatibility-large 
+
+   * - Feature
+     - Available in latest beta release
+
+   * - Distributed Transactions
+     - |checkmark|
+
+   * - Callback/Convenient API (Transaction Error Handling)
+     - |checkmark|
+
+   * - On-Demand Materialized Views
+     -
+
+   * - Index all paths
+     - |checkmark|
+
+   * - Expressive update
+     - |checkmark|
+
+   * - Retryable Reads
+     - |checkmark|
+
+   * - Retryable Writes On By Default
+     - |checkmark|
+
+   * - Keepalive Connections
+     - |checkmark|
+
+   * - Client-side Encryption
+     -
+
+.. include:: /includes/extracts/csharp-driver-compatibility-matrix-mongodb.rst
 
 .. list-table::
    :header-rows: 1

--- a/source/includes/mongodb-compatibility-table-java.rst
+++ b/source/includes/mongodb-compatibility-table-java.rst
@@ -1,3 +1,46 @@
+.. note:: MongoDB 4.2 Feature Availability
+
+   The following table specifies which key MongoDB 4.2 features are available in
+   `the latest beta release <https://github.com/mongodb/mongo-java-driver/releases/tag/r3.11.0-beta4>`__
+   of the driver:
+
+.. list-table::
+   :header-rows: 1
+   :stub-columns: 1
+   :class: compatibility-large 
+
+   * - Feature
+     - Available in latest beta release
+
+   * - Distributed Transactions
+     - |checkmark|
+
+   * - Callback/Convenient API (Transaction Error Handling)
+     - |checkmark|
+
+   * - On-Demand Materialized Views
+     - |checkmark|
+
+   * - Index all paths
+     - |checkmark|
+
+   * - Expressive update
+     - 
+
+   * - Retryable Reads
+     - |checkmark|
+
+   * - Retryable Writes On By Default
+     - |checkmark|
+
+   * - Keepalive Connections
+     - |checkmark|
+
+   * - Client-side Encryption
+     - |checkmark|
+
+.. include:: /includes/extracts/java-driver-compatibility-matrix-mongodb.rst
+
 .. list-table::
    :header-rows: 1
    :stub-columns: 1

--- a/source/includes/mongodb-compatibility-table-node.rst
+++ b/source/includes/mongodb-compatibility-table-node.rst
@@ -1,3 +1,47 @@
+.. note:: MongoDB 4.2 Feature Availability
+
+   The following table specifies which key MongoDB 4.2 features are available in
+   `the latest beta release <https://www.npmjs.com/package/mongodb/v/3.3.0-beta1>`__
+   of the driver:
+
+.. list-table::
+   :header-rows: 1
+   :stub-columns: 1
+   :class: compatibility-large 
+
+   * - Feature
+     - Available in latest beta release
+
+   * - Distributed Transactions
+     - |checkmark|
+
+   * - Callback/Convenient API (Transaction Error Handling)
+     - |checkmark|
+
+   * - On-Demand Materialized Views
+     -
+
+   * - Index all paths
+     - N/A
+
+   * - Expressive update
+     - |checkmark|
+
+   * - Retryable Reads
+     -
+
+   * - Retryable Writes On By Default
+     - |checkmark|
+
+   * - Keepalive Connections
+     -
+
+   * - Client-side Encryption
+     - |checkmark|
+
+
+.. include:: /includes/extracts/node-driver-compatibility-matrix-mongodb.rst
+
 .. list-table::
    :header-rows: 1
    :stub-columns: 1

--- a/source/includes/mongodb-compatibility-table-python.rst
+++ b/source/includes/mongodb-compatibility-table-python.rst
@@ -1,3 +1,47 @@
+.. note:: MongoDB 4.2 Feature Availability
+
+   The following table specifies which key MongoDB 4.2 features are available in
+   `the latest beta release <https://github.com/mongodb/mongo-python-driver/releases/tag/3.9.0b1>`__
+   of the driver:
+
+.. list-table::
+   :header-rows: 1
+   :stub-columns: 1
+   :class: compatibility-large 
+
+   * - Feature
+     - Available in latest beta release
+
+   * - Distributed Transactions
+     - |checkmark|
+
+   * - Callback/Convenient API (Transaction Error Handling)
+     - |checkmark|
+
+   * - On-Demand Materialized Views
+     - |checkmark|
+
+   * - Index all paths
+     - N/A
+
+   * - Expressive update
+     - |checkmark|
+
+   * - Retryable Reads
+     - |checkmark|
+
+   * - Retryable Writes On By Default
+     - |checkmark|
+
+   * - Keepalive Connections
+     - N/A
+
+   * - Client-side Encryption
+     - |checkmark|
+
+
+.. include:: /includes/extracts/python-driver-compatibility-matrix-mongodb.rst
+
 .. list-table::
    :header-rows: 1
    :stub-columns: 1


### PR DESCRIPTION
This adds the availability table to the MongoDB compatibility
section of the following drivers: Node, C#, Python, and Java.

### Staged
Please look at the Node, C#/.NET, Python, and Java landing pages
on the compatibility section:
https://docs-mongodbcom-staging.corp.mongodb.com/ecosystem/bush/docsp-5987-4.2-compat/drivers/node.html#mongodb-compatibility
https://docs-mongodbcom-staging.corp.mongodb.com/ecosystem/bush/docsp-5987-4.2-compat/drivers/pymongo.html#mongodb-compatibility
https://docs-mongodbcom-staging.corp.mongodb.com/ecosystem/bush/docsp-5987-4.2-compat/drivers/csharp.html#mongodb-compatibility
https://docs-mongodbcom-staging.corp.mongodb.com/ecosystem/bush/docsp-5987-4.2-compat/drivers/java.html#mongodb-compatibility

Please also look at the Driver compatibility page sections for each
of the above drivers:
https://docs-mongodbcom-staging.corp.mongodb.com/ecosystem/bush/docsp-5987-4.2-compat/drivers/driver-compatibility-reference.html
