### PR TITLE
DOCS-12847 Update links on Drivers index page

### DIFF
--- a/source/includes/driver-table.rst
+++ b/source/includes/driver-table.rst
@@ -25,9 +25,8 @@
    * - :doc:`C# </drivers/csharp>`
      - `Releases <https://github.com/mongodb/mongo-csharp-driver/releases>`__
      - `Source <https://github.com/mongodb/mongo-csharp-driver>`__
-     - `API <http://api.mongodb.com/csharp/current/>`__
+     - `API <http://mongodb.github.io/mongo-csharp-driver/>`__
      - `JIRA <https://jira.mongodb.org/browse/CSHARP>`__
-     - `Course <https://university.mongodb.com/courses/M101N/about>`__
 
    * - :doc:`Go </drivers/go>`
      - `Releases <https://github.com/mongodb/mongo-go-driver/releases>`__
@@ -39,16 +38,16 @@
    * - :doc:`Java </drivers/java>`
      - `Releases <https://github.com/mongodb/mongo-java-driver/releases>`__
      - `Source <https://github.com/mongodb/mongo-java-driver>`__
-     - `API <http://api.mongodb.com/java/current>`__
+     - `API <https://mongodb.github.io/mongo-java-driver/>`__
      - `JIRA <https://jira.mongodb.org/browse/JAVA>`__
-     - `Course <https://university.mongodb.com/courses/M101J/about>`__
+     - `Course <https://university.mongodb.com/courses/M220J/about>`__
 
    * - :doc:`Node.js </drivers/node>`
      - `Releases <https://github.com/mongodb/node-mongodb-native/releases>`__
      - `Source <https://github.com/mongodb/node-mongodb-native>`__
      - `API <https://mongodb.github.io/node-mongodb-native/>`__
      - `JIRA <https://jira.mongodb.org/browse/NODE>`__
-     - `Course <https://university.mongodb.com/courses/M101JS/about>`__
+     - `Course <https://university.mongodb.com/courses/M220JS/about>`__
 
    * - :doc:`Perl </drivers/perl>`
      - `Releases <https://metacpan.org/release/MongoDB>`__
@@ -69,7 +68,7 @@
      - `Source <https://github.com/mongodb/mongo-python-driver>`__
      - `API <http://api.mongodb.com/python/current>`__
      - `JIRA <https://jira.mongodb.org/browse/PYTHON>`__
-     - `Course <https://university.mongodb.com/courses/M101P/about>`__
+     - `Course <https://university.mongodb.com/courses/M220P/about>`__
 
    * - :ref:`Motor (Python async)<python-async-driver>`
      - `Releases <https://pypi.python.org/pypi/motor/>`__


### PR DESCRIPTION
- Updates the links to outdated api.mongodb.com pages
- Ruby and Python still have up-to-date api.mongodb.com pages, so
I left those links alone.
- Updates the MongoDB University course links for Python, Java
and JS.
- Remove deprecated C# course link

## JIRA
https://jira.mongodb.org/browse/DOCS-12847

## Staged
https://docs-mongodborg-staging.corp.mongodb.com/ecosystem/bush/docs-12847-java-api-link/index.html
