### PR TITLE
DOCS-11995 Update C#/.NET compatibility table

### DIFF
--- a/source/includes/language-compatibility-table-csharp.rst
+++ b/source/includes/language-compatibility-table-csharp.rst
@@ -2,20 +2,41 @@
 .. list-table::
    :header-rows: 1
    :stub-columns: 1
-   :class: compatibility-large
+   :class: compatibility-large no-padding
 
    * - Driver Version
      - .NET 3.5
      - .NET 4.0
      - .NET 4.5
      - .NET 4.6
+     - .NET 4.7
+     - .NET 4.8
      - .NET Core 1.0
      - .NET Core 1.1
      - .NET Core 2.0
+     - .NET Core 2.1
+     - .NET Core 2.2
+
+   * - Version 2.8
+     -
+     -
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
 
    * - Version 2.7
      -
      -
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -30,6 +51,10 @@
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
 
    * - Version 2.5
      -
@@ -39,10 +64,19 @@
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+
 
    * - Version 2.4
      -
      -
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -57,12 +91,20 @@
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
 
    * - Version 2.2
      -
      -
      - |checkmark|
      - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     -
+     -
      -
      -
      -
@@ -72,6 +114,10 @@
      -
      - |checkmark|
      - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     -
+     -
      -
      -
      -
@@ -81,6 +127,10 @@
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     -
+     -
      -
      -
      -
@@ -90,6 +140,11 @@
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     - |checkmark|
+     - |checkmark|
      -
      -
      -
+     -
+     -
+

--- a/source/includes/mongodb-compatibility-table-csharp.rst
+++ b/source/includes/mongodb-compatibility-table-csharp.rst
@@ -54,6 +54,14 @@
      - MongoDB 3.0
      - MongoDB 2.6
 
+   * - Version 2.8
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+
    * - Version 2.7
      - |checkmark|
      - |checkmark|


### PR DESCRIPTION
- Adds 2.8 driver version compatibility
- Updates language compatibility table to include .NET Core 2.1, Core 2.2,
Framwork 4.7 and Framework 4.8.

### JIRA
https://jira.mongodb.org/browse/DOCS-11995

### Staged

https://docs-mongodbcom-staging.corp.mongodb.com/ecosystem/bush/docs-11995-csharp-compat/drivers/driver-compatibility-reference.html#c-net-driver-compatibility

and https://docs-mongodbcom-staging.corp.mongodb.com/ecosystem/bush/docs-11995-csharp-compat/drivers/csharp.html#language-compatibility (single source)

