### PR TITLE
Add PHP 7.4 to the PHP driver compatibility list

### DIFF
--- a/source/includes/language-compatibility-table-php.rst
+++ b/source/includes/language-compatibility-table-php.rst
@@ -6,6 +6,7 @@
    :class: compatibility-large
 
    * - PHP Driver
+     - PHP 7.4
      - PHP 7.3
      - PHP 7.2
      - PHP 7.1
@@ -19,9 +20,11 @@
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     - |checkmark|
      -
 
    * - ext 1.5 + lib 1.4
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -31,6 +34,7 @@
 
    * - ext 1.4 + lib 1.3
      -
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -38,6 +42,7 @@
      - |checkmark|
 
    * - ext 1.3 + lib 1.2
+     -
      -
      - |checkmark|
      - |checkmark|


### PR DESCRIPTION
PHPC 1.6 and PHPLIB 1.5 officially support PHP 7.4 in its current state and will fully support it once released.