### PR TITLE
Kafka Source Connector - fix typo "updatelookup" => "updateLookup"

### DIFF
--- a/source/connectors/kafka-source.txt
+++ b/source/connectors/kafka-source.txt
@@ -159,7 +159,7 @@ an example source connector configuration file, see
      - string
      - | Determines what to return for update operations when using a Change Stream. When set to 'updateLookup', the change stream for partial updates will include both a delta describing the changes to the document as well as a copy of the entire document that was changed from *some point in time* after the change occurred.
        | **Default**: ""
-       | **Accepted Values**: "" or ``default`` or ``updatelookup``
+       | **Accepted Values**: "" or ``default`` or ``updateLookup``
 
    * - poll.await.time.ms
      - long


### PR DESCRIPTION
JIRA: none

Staging: https://docs-mongodbcom-staging.corp.mongodb.com/ecosystem/docsworker/ccho-kafka-source-typo-fix/connectors/kafka-source.html