### PR TITLE
(DOCSP-6911) - adds swift driver

### DIFF
--- a/source/drivers.txt
+++ b/source/drivers.txt
@@ -14,7 +14,7 @@ Drivers
 -------
 
 .. note::
-   
+
    For information on next generation MongoDB drivers, see the
    following blog posts:
 
@@ -44,8 +44,9 @@ For information on MongoDB licensing, see `MongoDB Licensing
       Ruby Driver  <https://docs.mongodb.com/ruby-driver/current/>
       Mongoid ODM  <https://docs.mongodb.com/mongoid/current/>
       Scala Driver </drivers/scala>
+      Swift Driver </drivers/swift>
 
-MongoDB ODM (Object-Document-Mapper) 
+MongoDB ODM (Object-Document-Mapper)
 ------------------------------------
 
 Mongoid is the officially supported ODM (Object-Document-Mapper)

--- a/source/drivers/community-supported-drivers.txt
+++ b/source/drivers/community-supported-drivers.txt
@@ -62,10 +62,10 @@ Community Supported Drivers Reference
     Provides access to MongoDB deployments for Synopse applications.
 
 - Django
-  
-  - `Djongo <https://github.com/nesdis/djongo>`_ - A Driver for 
+
+  - `Djongo <https://github.com/nesdis/djongo>`_ - A Driver for
     `Using Django with MongoDB <https://nesdis.github.io/djongo/>`_
-    
+
 - Elixir
 
   - `Elixir Driver <https://github.com/ericmj/mongodb>`_ - MongoDB
@@ -73,8 +73,8 @@ Community Supported Drivers Reference
 
   - `Elixir Driver <https://github.com/zookzook/elixir-mongodb-driver>`__ - An alternative MongoDB
     driver for Elixir based on the work of `Elixir Driver <https://github.com/ericmj/mongodb>`__
-    
-  - `Ecto adapter <https://github.com/michalmuskala/mongodb_ecto>`_ - MongoDB adapter 
+
+  - `Ecto adapter <https://github.com/michalmuskala/mongodb_ecto>`_ - MongoDB adapter
     for Ecto, a database wrapper and language integrated query for Elixir.
 
 - Entity
@@ -126,7 +126,7 @@ Community Supported Drivers Reference
 - JavaScript
 
   - `Narwhal <http://github.com/sergi/narwhal-mongodb>`_
-  
+
 - LabVIEW
 
   - `mongo-labview-driver
@@ -188,13 +188,13 @@ Community Supported Drivers Reference
   - `MongoEngine <http://mongoengine.org>`_
 
   - `MongoKit <http://namlook.github.com/mongokit/>`_
-  
+
   - `MongoKat <https://github.com/pricingassistant/mongokat>`_
 
   - `Monary <https://monary.readthedocs.io/>`_
 
   - `Django-mongonaut <https://github.com/jazzband/django-mongonaut>`_
-  
+
   - `TxMongo <https://github.com/twisted/txmongo>`_
 
 - R
@@ -209,9 +209,6 @@ Community Supported Drivers Reference
 - Swift
 
   - `MongoKitten <https://github.com/OpenKitten/MongoKitten>`_, - MongoDB driver for Swift
-  
-  - `Perfect-MongoDB <https://github.com/PerfectlySoft/Perfect-MongoDB>`_, - A Server Side Swift 
-    wrapper of libmongoc C driver.
 
 - Racket (PLT Scheme)
 

--- a/source/drivers/swift.txt
+++ b/source/drivers/swift.txt
@@ -1,0 +1,80 @@
+.. _swift-language-center:
+
+.. include:: /includes/unicode-checkmark.rst
+
+====================
+MongoDB Swift Driver
+====================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: twocols
+
+Introduction
+------------
+
+This is the official MongoDB Swift Driver.
+
+.. admonition:: Alpha Release
+   :class: important
+
+   The MongoDB Swift Driver is currently in alpha.
+
+- `Usage Guide <https://mongodb.github.io/mongo-swift-driver/index.html#example-usage>`__
+
+- `API Reference <https://mongodb.github.io/mongo-swift-driver>`__
+
+- `Changelog <https://github.com/mongodb/mongo-swift-driver/releases>`__
+
+- `Source Code <https://github.com/mongodb/mongo-swift-driver/>`__
+
+
+Installation
+------------
+
+See `Installation <https://mongodb.github.io/mongo-swift-driver/index.html#installation>`__
+
+
+Connect to MongoDB Atlas
+------------------------
+
+To connect to a :atlas:`MongoDB Atlas </>` cluster, use the :atlas:`Atlas connection string </driver-connection>` for your cluster:
+
+.. code-block:: swift
+
+   import MongoSwift
+
+   let client = try MongoClient("mongodb+srv://<username>:<password>@<cluster-url>/test?retryWrites=true&w=majority")
+   let db = client.db("test")
+
+   // your application logic
+   // free all resources
+   cleanupMongoSwift()
+
+Compatibility
+-------------
+
+MongoDB Compatibility
+~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/mongodb-compatibility-table-swift.rst
+
+Language Compatibility
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/language-compatibility-table-swift.rst
+
+How to get help
+---------------
+
+- Ask on `Stack Overflow <https://stackoverflow.com/questions/tagged/mongodb+swift>`__.
+- Visit our `Support Channels <https://docs.mongodb.com/manual/support/>`__.
+- See the :issue:`SWIFT` JIRA project to raise issues or request features.
+
+
+
+

--- a/source/includes/driver-table.rst
+++ b/source/includes/driver-table.rst
@@ -98,6 +98,13 @@
      - `API <https://mongodb.github.io/mongo-scala-driver/>`__
      - :issue:`JIRA <SCALA>`
      -
+
+   * - :doc:`Swift </drivers/swift>`
+     - `Releases <https://github.com/mongodb/mongo-swift-driver/releases>`__
+     - `Source <https://github.com/mongodb/mongo-swift-driver>`__
+     - `API <https://mongodb.github.io/mongo-swift-driver/>`__
+     - :issue:`JIRA <SWIFT>`
+     -
 ..
    * - :doc:`Haskell </drivers/haskell>`
      - `Releases <https://github.com/mongodb/mongodb-haskell/releases>`__

--- a/source/includes/language-compatibility-table-swift.rst
+++ b/source/includes/language-compatibility-table-swift.rst
@@ -1,0 +1,1 @@
+The MongoDB Swift driver requires Swift 5 or later.

--- a/source/includes/mongodb-compatibility-table-swift.rst
+++ b/source/includes/mongodb-compatibility-table-swift.rst
@@ -1,0 +1,22 @@
+.. list-table::
+   :header-rows: 1
+   :stub-columns: 1
+   :class: compatibility-large
+
+   * - Swift Driver
+     - MongoDB 4.2
+     - MongoDB 4.0
+     - MongoDB 3.6
+     - MongoDB 3.4
+     - MongoDB 3.2
+     - MongoDB 3.0
+     - MongoDB 2.6
+
+   * - 0.2.0
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     -
+     -
+     -
+     -


### PR DESCRIPTION
This adds a page for the Swift driver to ecosystem, noting that it is an alpha version. It also adds a language and mongodb compatibility table and removes the now deprecated Perfect-MongoDB driver from the list of community supported drivers. I did also check MongoKitten and it looks like it is actively developed so didn't remove it.

[Staged](https://docs-mongodbcom-staging.corp.mongodb.com/ecosystem/docsworker/DOCSP-6911/drivers/swift.html)