### PR TITLE
DOCSP-7793: CSFLE security strategies chart

### DIFF
--- a/source/drivers/php.txt
+++ b/source/drivers/php.txt
@@ -60,8 +60,18 @@ You can install the extension using
 
 .. code-block:: sh
 
-   $ pecl install mongodb
-   $ echo "extension=mongodb.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`
+   $ sudo pecl install mongodb
+
+Finally, add the following line to your ``php.ini`` file:
+
+.. code-block:: text
+
+   extension=mongodb.so
+
+.. note::
+
+   On some systems, there may be multiple INI files for individual SAPIs (e.g.
+   CLI, FPM). Make sure to enable the extension in all SAPIs that you need.
 
 The preferred method of installing the PHP library is with
 `Composer <https://getcomposer.org/>`_ by running the following from your project root:

--- a/source/use-cases/client-side-field-level-encryption-guide.txt
+++ b/source/use-cases/client-side-field-level-encryption-guide.txt
@@ -44,7 +44,6 @@ MongoDB offers several methods that protect your data from unauthorized
 access including:
 
 * `Role-based access control <https://docs.mongodb.com/manual/core/authorization/>`_
-* `Monitoring and logging <https://docs.mongodb.com/manual/core/auditing/>`_
 * `TLS/SSL network transport encryption <https://docs.mongodb.com/manual/core/security-transport-encryption/>`_
 * `Encryption at rest <https://docs.mongodb.com/manual/core/security-encryption-at-rest/>`_
 
@@ -146,6 +145,12 @@ form. This mechanism keeps the specified data fields secure in encrypted
 form on both the server and the network. While all clients have access
 to the non-sensitive data fields, only appropriately-configured CSFLE
 clients are able to read and write the sensitive data fields.
+
+The following diagram is a breakdown of the MongoDB security features
+offered and the potential vulnerabilities that they address:
+
+.. image:: /figures/CSFLE_Security_Feature_Chart.png
+   :alt: Diagram that describes MongoDB security features and the potential vulnerabilities that they address
 
 MedcoMD will provide Receptionists with a client that is not configured
 to access data encrypted with CSFLE. This will prevent them from viewing


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/DOCSP-7793

Staging: https://docs-mongodbcom-staging.corp.mongodb.com/ecosystem/docsworker/DOCSP-7793-CSFLE-security-strategies-chart/use-cases/client-side-field-level-encryption-guide.html

docs-assets PR (must be merged into ecosystem branch before building on staging:  https://github.com/mongodb/docs-assets/pull/40