### PR TITLE
Escape slashes in class name

### DIFF
--- a/source/drivers/php.txt
+++ b/source/drivers/php.txt
@@ -107,7 +107,7 @@ Compatibility
 Due to potential problems representing 64-bit integers on 32-bit platforms,
 users are advised to use 64-bit environments. When using a 32-bit platform, be
 aware that any 64-bit integer read from the database will be returned as a
-`MongoDB\BSON\Int64 <https://www.php.net/manual/en/class.mongodb-bson-int64.php>`_
+`MongoDB\\BSON\\Int64 <https://www.php.net/manual/en/class.mongodb-bson-int64.php>`_
 instance instead of a PHP integer type.
 
 MongoDB Compatibility


### PR DESCRIPTION
Fixes https://github.com/mongodb/docs-ecosystem/commit/dd24fdb130917681cde5c45646a17bb3a48de18c#diff-90020279a86a94415c6f59c61c9125a3