### PR TITLE
remove unused extract

### DIFF
--- a/source/drivers/reactive-streams.txt
+++ b/source/drivers/reactive-streams.txt
@@ -84,8 +84,6 @@ MongoDB Compatibility
 Language Compatibility
 ~~~~~~~~~~~~~~~~~~~~~~
 
-.. include:: /includes/extracts/java-rs-driver-compatibility-matrix-language.rst
-
 .. include:: /includes/language-compatibility-table-java-rs.rst
 
 How to get help


### PR DESCRIPTION
Fix for a warning caused by reference to a nonexistent file.

JIRA: none

Staging:
https://docs-mongodbcom-staging.corp.mongodb.com/ecosystem/docsworker/DOCSP-2157-reactive-streams-page/drivers/java.html