### PR TITLE
DOCS-10899: update driver specs table

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -64,6 +64,7 @@ extlinks = {
     'issue': ('https://jira.mongodb.org/browse/%s', ''),
     'api': ('https://api.mongodb.com/%s', ''),
     'manual': ('https://docs.mongodb.org/manual%s', ''),
+    'spec': ('https://github.com/mongodb/specifications/blob/master/source%s', ''),
     'gettingstarted': ('https://docs.mongodb.org/getting-started%s', ''),
     'atlas': ('https://docs.atlas.mongodb.com%s', ''),
     'mms-home': ('https://www.mongodb.com/cloud/cloud-manager%s', ''),

--- a/source/drivers/specs.txt
+++ b/source/drivers/specs.txt
@@ -12,7 +12,7 @@ what they apply to.
   a production-ready MongoDB deployment.
 - **API** specs define drivers' APIs.
 - **Advanced Features** specs describe features for interacting with
-  MongoDB 2.6 and earlier and other features that are not mandatory for
+  MongoDB 2.6 and later and other features that are not mandatory for
   production deployments.
 
 .. list-table::
@@ -27,39 +27,47 @@ what they apply to.
      - |checkmark|
      -
      -
-   * - `Authentication - SCRAM-SHA-1 <https://github.com/mongodb/specifications/tree/master/source/auth>`_
+   * - :spec:`Authentication </auth/auth.rst>`
      - |checkmark|
      -
      -
-   * - `SSL <https://docs.mongodb.com/manual/tutorial/configure-ssl-clients/>`_
+   * - :spec:`Authentication: SCRAM-SHA-1, SCRAM-SHA-256, X509 </auth/auth.rst>`
+     -
+     -
+     - |checkmark|
+   * - :spec:`Authentication (Enterprise only): GSSAPI, PLAIN </auth>`
+     -
+     -
+     - |checkmark|
+   * - :manual:`TLS/SSL </tutorial/configure-ssl-clients/>`
      - |checkmark|
      -
      -
-   * - `Server Discovery and Monitoring <https://github.com/mongodb/specifications/tree/master/source/server-discovery-and-monitoring>`_
+   * - :spec:`Server Discovery and Monitoring (SDAM) </server-discovery-and-monitoring/server-discovery-and-monitoring-monitoring.rst>`
      - |checkmark|
      -
      -
-   * - `Server Selection <https://github.com/mongodb/specifications/tree/master/source/server-selection>`_
+   * - :spec:`Server Selection </server-selection/server-selection.rst>`
      - |checkmark|
      -
      -
-   * - `Max Staleness <https://github.com/mongodb/specifications/tree/master/source/max-staleness>`_
+   * - :spec:`Max Staleness </max-staleness/max-staleness.rst>`
      - |checkmark|
      -
      -
-   * - `Read and Write Concern <https://github.com/mongodb/specifications/tree/master/source/read-write-concern>`_
+   * - :spec:`Read and Write Concern </read-write-concern/read-write-concern.rst>`
      - |checkmark|
      -
      -
-   * - `Decimal Data Type <https://github.com/mongodb/specifications/blob/master/source/bson-decimal128/decimal128.rst>`_
+   * - :spec:`Decimal Data Type </bson-decimal128/decimal128.rst>`
      - |checkmark|
      -
      -
-   * - `MongoDB Handshake <https://github.com/mongodb/specifications/blob/master/source/mongodb-handshake/handshake.rst>`_
+   * - :spec:`MongoDB Handshake </mongodb-handshake/handshake.rst>`
      - |checkmark|
      -
      -
-   * - `Collation	<https://github.com/mongodb/specifications/blob/master/source/collation/collation.rst>`_
+   * - :spec:`Collation	</collation/collation.rst>`
      - |checkmark|
      -
      -
@@ -67,86 +75,86 @@ what they apply to.
      - |checkmark|
      -
      -
-   * - `OP_MSG <https://github.com/mongodb/specifications/blob/master/source/message/OP_MSG.rst>`_
+   * - :spec:`OP_MSG </message/OP_MSG.rst>`
      - |checkmark|
      -
      -
-   * - `Initial DNS Seedlist Discovery <https://github.com/mongodb/specifications/blob/master/source/initial-dns-seedlist-discovery/initial-dns-seedlist-discovery.rst>`_
+   * - :spec:`Initial DNS Seedlist Discovery </initial-dns-seedlist-discovery/initial-dns-seedlist-discovery.rst>`
      - |checkmark|
      -
      -
-   * - `Transactions <https://github.com/mongodb/specifications/blob/master/source/transactions/transactions.rst>`_
+   * - :spec:`Transactions </transactions/transactions.rst>`
      - |checkmark|
      -
      -
-   * - `Polling SRV Records for mongos Discovery <https://github.com/mongodb/specifications/blob/master/source/polling-srv-records-for-mongos-discovery/polling-srv-records-for-mongos-discovery.rst>`_
+   * - :spec:`Polling SRV Records for mongos Discovery </polling-srv-records-for-mongos-discovery/polling-srv-records-for-mongos-discovery.rst>`
      - |checkmark|
      -
      -
-   * - `URI options <https://github.com/mongodb/specifications/blob/master/source/uri-options/uri-options.rst>`_
+   * - :spec:`URI options </uri-options/uri-options.rst>`
      - |checkmark|
      -
      -
-   * - `Convenient API for Transactions  <https://github.com/mongodb/specifications/blob/master/source/transactions-convenient-api/transactions-convenient-api.rst>`_
+   * - :spec:`Convenient API for Transactions  </transactions-convenient-api/transactions-convenient-api.rst>`
      - |checkmark|
      -
      -
-   * - `Connection Monitoring and Pooling <https://github.com/mongodb/specifications/blob/master/source/connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst>`_
+   * - :spec:`Connection Monitoring and Pooling </connection-monitoring-and-pooling/connection-monitoring-and-pooling.rst>`
      - |checkmark|
      -
-     -  
-   * - `Connection String <https://github.com/mongodb/specifications/blob/master/source/connection-string/connection-string-spec.rst>`_
      -
-     - |checkmark|
-     -
-   * - `CRUD <https://github.com/mongodb/specifications/tree/master/source/crud>`_
+   * - :spec:`Connection String </connection-string/connection-string-spec.rst>`
      -
      - |checkmark|
      -
-   * - `Index Management <https://github.com/mongodb/specifications/blob/master/source/index-management.rst>`_
+   * - :spec:`CRUD operations </crud/crud.rst>`
      -
      - |checkmark|
      -
-   * - `Find, getMore and killCursors commands <https://github.com/mongodb/specifications/blob/master/source/find_getmore_killcursors_commands.rst>`_
+   * - :spec:`Index Management </index-management.rst>`
      -
      - |checkmark|
      -
-   * - `Driver Bulk update <https://github.com/mongodb/specifications/blob/master/source/driver-bulk-update.rst>`_
+   * - :spec:`Find, getMore and killCursors commands </find_getmore_killcursors_commands.rst>`
      -
      - |checkmark|
      -
-   * - `Enumerate Collections <https://github.com/mongodb/specifications/blob/master/source/enumerate-collections.rst>`_
+   * - :spec:`Driver Bulk update </driver-bulk-update.rst>`
      -
      - |checkmark|
      -
-   * - `Out aggregation pipeline operator <https://github.com/mongodb/specifications/blob/master/source/out-aggregation-pipeline-operator.rst>`_
+   * - :spec:`Enumerate Collections </enumerate-collections.rst>`
      -
      - |checkmark|
      -
-   * - `Server write commands	<https://github.com/mongodb/specifications/blob/master/source/server_write_commands.rst>`_
+   * - :spec:`Out aggregation pipeline operator </out-aggregation-pipeline-operator.rst>`
      -
      - |checkmark|
      -
-   * - `Logical Sessions   <https://github.com/mongodb/specifications/blob/master/source/sessions/driver-sessions.rst>`_
+   * - :spec:`Server write commands	</server_write_commands.rst>`
      -
      - |checkmark|
      -
-   * - `Retryable Writes   <https://github.com/mongodb/specifications/blob/master/source/retryable-writes/retryable-writes.rst>`_
+   * - :spec:`Logical Sessions </sessions/driver-sessions.rst>`
      -
      - |checkmark|
      -
-   * - `Change Streams <https://github.com/mongodb/specifications/blob/master/source/change-streams/change-streams.rst>`_
+   * - :spec:`Retryable Writes </retryable-writes/retryable-writes.rst>`
      -
      - |checkmark|
      -
-   * - `Causally Consistent Reads   <https://github.com/mongodb/specifications/blob/master/source/causal-consistency/causal-consistency.rst>`_
+   * - :spec:`Change Streams </change-streams/change-streams.rst>`
      -
      - |checkmark|
      -
-   * - `Enumerate Databases   <https://github.com/mongodb/specifications/blob/master/source/enumerate-databases.rst>`_
-     - 
+   * - :spec:`Causally Consistent Reads </causal-consistency/causal-consistency.rst>`
+     -
      - |checkmark|
-     - 
+     -
+   * - :spec:`Enumerate Databases </enumerate-databases.rst>`
+     -
+     - |checkmark|
+     -
    * - `OP_QUERY, OP_GET_MORE, OP_KILL_CURSOR, OP_REPLY <http://docs.mongodb.org/meta-driver/latest/legacy/mongodb-wire-protocol/>`_
      - |checkmark|
      -
@@ -155,35 +163,19 @@ what they apply to.
      - |checkmark|
      -
      -
-   * - `Auth - MONGODB CR <https://github.com/mongodb/specifications/tree/master/source/auth>`_
+   * - :spec:`Command Monitoring </command-monitoring/command-monitoring.rst>`
+     - |checkmark|
      -
+     -
+   * - :spec:`SDAM Monitoring </server-discovery-and-monitoring/server-discovery-and-monitoring-monitoring.rst>`
+     - |checkmark|
+     -
+     -
+   * - :spec:`GridFS </gridfs/gridfs-spec.rst>`
      -
      - |checkmark|
-   * - `Auth - X509 <https://github.com/mongodb/specifications/tree/master/source/auth>`_
      -
-     -
-     - |checkmark|
-   * - `Auth - PLAIN <https://github.com/mongodb/specifications/tree/master/source/auth>`_
-     -
-     -
-     - |checkmark|
-   * - `Auth - GSSAPI <https://github.com/mongodb/specifications/tree/master/source/auth>`_
-     -
-     -
-     - |checkmark|
-   * - `Command Monitoring <https://github.com/mongodb/specifications/blob/master/source/command-monitoring/command-monitoring.rst>`_
-     -
-     -
-     - |checkmark|
-   * - `SDAM Monitoring <https://github.com/mongodb/specifications/tree/master/source/server-discovery-and-monitoring>`_
-     -
-     -
-     - |checkmark|
-   * - `GridFS <https://github.com/mongodb/specifications/blob/master/source/gridfs/gridfs-spec.rst>`_
-     -
-     -
-     - |checkmark|
-   * - `OP_COMPRESSED <https://github.com/mongodb/specifications/blob/master/source/compression/OP_COMPRESSED.rst>`_
+   * - :spec:`OP_COMPRESSED </compression/OP_COMPRESSED.rst>`
      - |checkmark|
      -
      -


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/DOCS-10899

Staging: https://docs-mongodborg-staging.corp.mongodb.com/ecosystem/docsworker/DOCS-10899-driver-specs-table-update/index.html

- Updated extlinks for specs
- Clarified MongoDB 2.6 and later
- Moved GridFS, SDAM, and Command Monitoring checkmarks to Core Driver column
- Removed mention of MONGODB-CR
- Consolidated and labeled non-enterprise and enterprise auth
- Updated several links to point directly to rst files rather than directory containing them on GitHub.