### PR TITLE
(DOCSP-9809) - adds swift and rust compat

### DIFF
--- a/source/driver-compatibility-reference.txt
+++ b/source/driver-compatibility-reference.txt
@@ -632,6 +632,19 @@ Ruby Compatibility
      -
      - |checkmark|
 
+Rust Driver Compatibility
+-------------------------
+
+MongoDB Compatibility
+~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/mongodb-compatibility-table-rust.rst
+
+Language Compatibility
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/language-compatibility-table-rust.rst
+
 
 Scala Driver Compatibility
 --------------------------
@@ -655,3 +668,17 @@ Language Compatibility
 .. include:: /includes/language-compatibility-table-scala.rst
 
 .. include:: /includes/unicode-checkmark.rst
+
+Swift Driver Compatibility
+--------------------------
+
+MongoDB Compatibility
+~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/mongodb-compatibility-table-swift.rst
+
+Language Compatibility
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: /includes/language-compatibility-table-swift.rst
+

--- a/source/includes/language-compatibility-table-csharp.rst
+++ b/source/includes/language-compatibility-table-csharp.rst
@@ -2,7 +2,7 @@
 .. list-table::
    :header-rows: 1
    :stub-columns: 1
-   :class: compatibility-large no-padding
+   :class: compatibility-large
 
    * - Driver Version
      - .NET 3.5

--- a/source/includes/language-compatibility-table-csharp.rst
+++ b/source/includes/language-compatibility-table-csharp.rst
@@ -2,7 +2,7 @@
 .. list-table::
    :header-rows: 1
    :stub-columns: 1
-   :class: compatibility-large
+   :class: compatibility-large no-padding
 
    * - Driver Version
      - .NET 3.5


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-9809

### Docs staging link:
https://docs-mongodbcom-staging.corp.mongodb.com/861ea72/drivers/docsworker/DOCSP-9809/driver-compatibility-reference

### A/C:
- [x] Swift compatibility added in lexicographic order
- [x] Rust compatibility added in lexicographic order