### PR TITLE
DOCS-13630: python compatibility matrix update for 3.10 and 3.11

### DIFF
--- a/source/includes/language-compatibility-table-python.rst
+++ b/source/includes/language-compatibility-table-python.rst
@@ -13,6 +13,18 @@ Python 2 Compatibility
      - Python 2.6
      - Python 2.7, PyPy
 
+   * - 3.11 (beta)
+     -
+     -
+     -
+     - |checkmark|
+
+   * - 3.10
+     -
+     -
+     -
+     - |checkmark|
+
    * - 3.9
      -
      -
@@ -109,6 +121,26 @@ Python 3 Compatibility
      - Python 3.5
      - Python 3.6
      - Python 3.7
+
+   * - 3.11 (beta)
+     -
+     -
+     - |checkmark|
+     -
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+
+   * - 3.10
+     -
+     -
+     - |checkmark|
+     -
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
 
    * - 3.9
      -

--- a/source/includes/mongodb-compatibility-table-python.rst
+++ b/source/includes/mongodb-compatibility-table-python.rst
@@ -15,6 +15,24 @@
      - MongoDB 3.0
      - MongoDB 2.6
 
+   * - 3.11 (beta)
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+
+   * - 3.10
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+
    * - 3.9
      - |checkmark|
      - |checkmark|


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCS-13630

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/954cf73/drivers/docsworker/DOCS-13630-python-compat-matrix/pymongo
