### PR TITLE
DOP-958: Update community drivers page

### DIFF
--- a/source/community-supported-drivers.txt
+++ b/source/community-supported-drivers.txt
@@ -64,7 +64,6 @@ Community Libraries
 
    * - Groovy
      - | `gmongo <https://github.com/poiati/gmongo>`__
-       | Blog Post: `Groovy on Grails in the land of MongoDB <http://blog.mongodb.com/post/18510469058/grails-in-the-land-of-mongodb>`__
        | `Grails Bates: Grails business audit trails plugin <https://github.com/saleram1/grails-bates>`__
 
    * - Haskell
@@ -77,7 +76,7 @@ Community Libraries
      - `mongo-labview-driver <https://github.com/RBXSystems/mongo-labview-driver>`__
 
    * - Lisp
-     - `<https://github.com/fons/cl-mongo>`__
+     - `cl-mongo <https://github.com/fons/cl-mongo>`__
 
    * - Lua
      - | `LuaMongo on Google Code <http://code.google.com/p/luamongo/>`__

--- a/source/community-supported-drivers.txt
+++ b/source/community-supported-drivers.txt
@@ -1,206 +1,141 @@
-.. _community-supported-drivers:
-
-=====================================
-Community Supported Drivers Reference
-=====================================
-
-- ActionScript3
-
-  - `<http://code.google.com/p/jmcnet-full-mongo-flex-driver/>`_
-
-- C
-
-  - `libmongo-client <http://github.com/algernon/libmongo-client>`_
-
-- ColdFusion
-
-  - `cfmongodb <https://github.com/marcesher/cfmongodb/>`_
-
-- D
-
-  - `Vibe.D native MongoDB driver <http://vibed.org/docs#mongo>`_
-
-  - `Port of the legacy MongoDB 0.4 C Driver to D
-    <http://github.com/itiu/mongo-d-driver>`_
-
-- Dart
-
-  - `<http://pub.dartlang.org/packages/mongo_dart>`_
-
-- Delphi
-
-  - `mongo-delphi-driver
-    <https://github.com/gerald-lindsly/mongo-delphi-driver>`_ - Full
-    featured Delphi interface to MongoDB built on top of the
-    legacy MongoDB C driver
-
-  - `pebongo <http://code.google.com/p/pebongo/>`_ - Early stage Delphi
-    driver for MongoDB
-
-  - `TMongoWire <http://github.com/stijnsanders/TMongoWire>`_ - Basic
-    and clean wrapper around the MongoDB wire protocol.
-
-  - `Alcinoe TALMongoClient
-    <https://github.com/Zeus64/alcinoe/>`_ - A Delphi
-    component suite that includes support for MongoDB
-
-  - `Synopse mORMot framework
-    <http://blog.synopse.info/post/2014/05/07/MongoDB-database-access>`_ -
-    Provides access to MongoDB deployments for Synopse applications.
-
-- Django
-
-  - `Djongo <https://github.com/nesdis/djongo>`_ - A Driver for
-    `Using Django with MongoDB <https://nesdis.github.io/djongo/>`_
-
-- Elixir
-
-  - `Elixir Driver <https://github.com/ericmj/mongodb>`_ - MongoDB
-    driver in Elixir, a functional language built on top of the Erlang VM.
-
-  - `Elixir Driver <https://github.com/zookzook/elixir-mongodb-driver>`__ - An alternative MongoDB
-    driver for Elixir based on the work of `Elixir Driver <https://github.com/ericmj/mongodb>`__
-
-  - `Ecto adapter <https://github.com/michalmuskala/mongodb_ecto>`_ - MongoDB adapter
-    for Ecto, a database wrapper and language integrated query for Elixir.
-
-- Entity
-
-  - `entity driver for mongodb
-    <http://code.google.com/p/entity-language/wiki/mongodb>`_ on Google
-    Code, included within the standard Entity Library
-
-- Erlang
-
-  - `Erlang Driver <https://github.com/comtihon/mongodb-erlang>`_ - Formerly the officially
-    maintained MongoDB Erlang driver, now maintained by community member Comtihon.
-
-- Factor
-
-  - `Factor <http://github.com/slavapestov/factor/tree/master/extra/mongodb/>`_
-
-- Fantom
-
-  - `afMongo <http://pods.fantomfactory.org/pods/afMongo>`_ - a MongoDB driver written in pure Fantom.
-
-  - `afMorphia <http://pods.fantomfactory.org/pods/afMorphia>`_ - a Fantom to MongoDB object mapping library.
-
-  - `FantoMongo <http://bitbucket.org/liamstask/fantomongo/wiki/Home>`_
-
-- F#
-
-  - `F# <http://gist.github.com/218388>`_
-
-- Go
-
-  - `mgo (GlobalSign fork) <https://github.com/globalsign/mgo>`_ - GlobalSign fork of the mgo driver
-    with improved support for newer versions of MongoDB (3.2, 3.4+).
-
-- Groovy
-
-  - `gmongo <https://github.com/poiati/gmongo>`_
-
-  - Blog Post: `Groovy on Grails in the land of MongoDB
-    <http://blog.mongodb.com/post/18510469058/grails-in-the-land-of-mongodb>`_
-
-  - `Grails Bates: Grails business audit trails plugin
-    <https://github.com/saleram1/grails-bates>`_
-
-- Haskell
-
-  - `mongoDB <https://github.com/mongodb-haskell/mongodb>`_, MongoDB driver for Haskell.
-
-- JavaScript
-
-  - `Narwhal <http://github.com/sergi/narwhal-mongodb>`_
-
-- LabVIEW
-
-  - `mongo-labview-driver
-    <https://github.com/RBXSystems/mongo-labview-driver>`_
-
-- Lisp
-
-  - `<https://github.com/fons/cl-mongo>`_
-
-- Lua
-
-  - `LuaMongo on Google Code <http://code.google.com/p/luamongo/>`_
-
-  - `LuaMongo <https://github.com/moai/luamongo>`_ fork on Github
-
-- Mathematica
-
-  - `MongoDBLink <https://github.com/zbjornson/MongoDBLink>`_
-
-- MatLab
-
-  - `mongo-matlab-driver
-    <https://github.com/gerald-lindsly/mongo-matlab-driver>`_
-
-- Objective C
-
-  - `NuMongoDB <http://github.com/timburks/NuMongoDB>`_
-
-  - `ObjCMongoDB <https://github.com/paulmelnikow/ObjCMongoDB>`_
-
-- OCaml
-
-  - `Mongo.ml <http://massd.github.io/mongo>`_
-
-- Opa
-
-  - `Opa Standard Library MongoDB Driver
-    <https://github.com/MLstate/opalang/wiki/Hello%2C-database>`_
-
-- Perl
-
-  - `Mango <https://metacpan.org/pod/Mango>`_ - A non-blocking
-    pure-Perl driver based on `Mojolicious <https://mojolicious.org/>`_
-
-- :ref:`PHP Libraries, Frameworks, and Tools <php-libraries-frameworks-and-tools>`
-
-- PowerShell
-
-  - `mosh - MongoDB Powershell provider <http://mosh.codeplex.com>`_
-
-  - `Mdbc - MongoDB Cmdlets for PowerShell <https://github.com/nightroman/Mdbc>`_
-
-- Prolog
-
-  - `Prolongo <https://github.com/khueue/prolongo>`_
-
-- Python
-
-  - `MongoEngine <http://mongoengine.org>`_
-
-  - `MongoKit <http://namlook.github.com/mongokit/>`_
-
-  - `MongoKat <https://github.com/pricingassistant/mongokat>`_
-
-  - `Monary <https://monary.readthedocs.io/>`_
-
-  - `Django-mongonaut <https://github.com/jazzband/django-mongonaut>`_
-
-  - `TxMongo <https://github.com/twisted/txmongo>`_
-
-- R
-
-  - `mongolite <https://cran.r-project.org/web/packages/mongolite/>`_ - High-level,
-    high-performance MongoDB client based on libmongoc and jsonlite
-
-- Scala
-
-  - `Reactive-Mongo <http://reactivemongo.org/>`_
-
-- Swift
-
-  - `MongoKitten <https://github.com/OpenKitten/MongoKitten>`_, - MongoDB driver for Swift
-
-- Racket (PLT Scheme)
-
-  - `mongodb.plt <http://planet.racket-lang.org/display.ss?package=mongodb.plt&owner=jaymccarthy&changerep=2>`_
-
-- Smalltalk
-
-  - `Squeaksource MongoTalk <http://www.squeaksource.com/MongoTalk.html>`_
+:orphan:
+:template: landing
+
+===================
+Community Libraries
+===================
+
+.. include:: /includes/important-community-drivers.rst
+
+.. list-table::
+   :width: 100%
+
+   * - ActionScript3
+     - `JMCNetMongoFlex <http://code.google.com/p/jmcnet-full-mongo-flex-driver/>`__
+    
+   * - C
+     - `libmongo-client <http://github.com/algernon/libmongo-client>`__
+  
+   * - ColdFusion
+     - `cfmongodb <https://github.com/marcesher/cfmongodb/>`__
+    
+   * - D
+     - | `Vibe.D native MongoDB driver <http://vibed.org/docs#mongo>`__
+       | `Port of the legacy MongoDB 0.4 C Driver to D <http://github.com/itiu/mongo-d-driver>`__
+
+   * - Dart
+     - `mongo_dart 0.4.0 <http://pub.dartlang.org/packages/mongo_dart>`__
+
+   * - Delphi
+     - | `mongo-delphi-driver <https://github.com/gerald-lindsly/mongo-delphi-driver>`__
+       | `pebongo <http://code.google.com/p/pebongo/>`__
+       | `TMongoWire <http://github.com/stijnsanders/TMongoWire>`__
+       | `Alcinoe TALMongoClient <https://github.com/Zeus64/alcinoe/>`__ 
+       | `Synopse mORMot framework <http://blog.synopse.info/post/2014/05/07/MongoDB-database-access>`__
+        
+   * - Django
+     - `Djongo <https://github.com/nesdis/djongo>`__
+
+   * - Elixir
+     - | `Elixir Driver <https://github.com/ericmj/mongodb>`__
+       | `Elixir Driver Alternate <https://github.com/zookzook/elixir-mongodb-driver>`__
+       | `Ecto adapter <https://github.com/michalmuskala/mongodb_ecto>`__
+
+   * - Entity
+     - `entity driver for mongodb <http://code.google.com/p/entity-language/wiki/mongodb>`__
+
+   * - Erlang
+     - `Erlang Driver <https://github.com/comtihon/mongodb-erlang>`__
+
+   * - Factor
+     - `Factor <http://github.com/slavapestov/factor/tree/master/extra/mongodb/>`__
+
+   * - Fantom
+     - | `afMongo <http://pods.fantomfactory.org/pods/afMongo>`__
+       | `afMorphia <http://pods.fantomfactory.org/pods/afMorphia>`__
+       | `FantoMongo <http://bitbucket.org/liamstask/fantomongo/wiki/Home>`__
+
+   * - F#
+     - `F# <http://gist.github.com/218388>`__
+
+   * - Go
+     - `mgo (GlobalSign fork) <https://github.com/globalsign/mgo>`__
+
+   * - Groovy
+     - | `gmongo <https://github.com/poiati/gmongo>`__
+       | Blog Post: `Groovy on Grails in the land of MongoDB <http://blog.mongodb.com/post/18510469058/grails-in-the-land-of-mongodb>`__
+       | `Grails Bates: Grails business audit trails plugin <https://github.com/saleram1/grails-bates>`__
+
+   * - Haskell
+     - `MongoDB driver for Haskell <https://github.com/mongodb-haskell/mongodb>`__
+
+   * - JavaScript
+     - `Narwhal <http://github.com/sergi/narwhal-mongodb>`__
+
+   * - LabVIEW
+     - `mongo-labview-driver <https://github.com/RBXSystems/mongo-labview-driver>`__
+
+   * - Lisp
+     - `<https://github.com/fons/cl-mongo>`__
+
+   * - Lua
+     - | `LuaMongo on Google Code <http://code.google.com/p/luamongo/>`__
+       | `LuaMongo <https://github.com/moai/luamongo>`__
+
+   * - Mathematica
+     - `MongoDBLink <https://github.com/zbjornson/MongoDBLink>`__
+
+   * - MatLab
+     - `mongo-matlab-driver <https://github.com/gerald-lindsly/mongo-matlab-driver>`__
+
+   * - Objective C
+     - | `NuMongoDB <http://github.com/timburks/NuMongoDB>`__
+       | `ObjCMongoDB <https://github.com/paulmelnikow/ObjCMongoDB>`__
+
+   * - OCaml
+     - `Mongo.ml <http://massd.github.io/mongo>`__
+
+   * - Opa
+     - `Opa Standard Library MongoDB Driver <https://github.com/MLstate/opalang/wiki/Hello%2C-database>`__
+
+   * - Perl
+     - `Mango <https://metacpan.org/pod/Mango>`__
+
+   * - PHP
+     - | `Mongo Queue PHP <https://github.com/dominionenterprises/mongo-queue-php>`__
+       | `Mongo PHP Adapter <https://github.com/alcaeus/mongo-php-adapter>`__
+       | `Mongodm <https://github.com/purekid/mongodm>`__
+       | `MongoDB Transistor <https://github.com/bjori/mongo-php-transistor>`__
+       | `Yadm <https://github.com/makasim/yadm>`__
+
+   * - PowerShell
+     - | `mosh - MongoDB Powershell provider <http://mosh.codeplex.com>`__
+       | `Mdbc - MongoDB Cmdlets for PowerShell <https://github.com/nightroman/Mdbc>`__ 
+
+   * - Prolog
+     - `Prolongo <https://github.com/khueue/prolongo>`__
+
+   * - Python
+     - | `MongoEngine <http://mongoengine.org>`__
+       | `MongoKit <http://namlook.github.com/mongokit/>`__
+       | `MongoKat <https://github.com/pricingassistant/mongokat>`__
+       | `Monary <https://monary.readthedocs.io/>`__
+       | `Django-mongonaut <https://github.com/jazzband/django-mongonaut>`__
+       | `TxMongo <https://github.com/twisted/txmongo>`__
+
+   * - R
+     - `mongolite <https://cran.r-project.org/web/packages/mongolite/>`__
+
+   * - Scala
+     - `Reactive-Mongo <http://reactivemongo.org/>`__
+
+   * - Swift
+     - `MongoKitten <https://github.com/OpenKitten/MongoKitten>`__
+
+   * - Racket (PLT Scheme)
+     - `mongodb.plt <http://planet.racket-lang.org/display.ss?package=mongodb.plt&owner=jaymccarthy&changerep=2>`__
+
+   * - Smalltalk
+     - `Squeaksource MongoTalk <http://www.squeaksource.com/MongoTalk.html>`__
+
+.. include:: /includes/important-community-drivers.rst

--- a/source/community-supported-drivers.txt
+++ b/source/community-supported-drivers.txt
@@ -9,6 +9,7 @@ Community Libraries
 
 .. list-table::
    :width: 100%
+   :class: striped
 
    * - ActionScript3
      - `JMCNetMongoFlex <http://code.google.com/p/jmcnet-full-mongo-flex-driver/>`__

--- a/source/drivers.txt
+++ b/source/drivers.txt
@@ -54,15 +54,6 @@ Mongoid is the officially supported ODM (Object-Document-Mapper)
 framework for MongoDB in Ruby. For documentation, see `Mongoid
 Documentation <https://docs.mongodb.com/mongoid/master/>`_.
 
-
-Community Supported Drivers
----------------------------
-
-.. toctree::
-   :titlesonly:
-
-   /community-supported-drivers
-
 Reference
 ---------
 

--- a/source/includes/important-community-drivers.rst
+++ b/source/includes/important-community-drivers.rst
@@ -4,4 +4,4 @@
    by MongoDB in any way. They are solely created and supported by
    the community.
 
-   Don't see your library on this page? `Submit it here <https://jira.mongodb.org/secure/CreateIssueDetails!init.jspa?pid=10380&issuetype=4>`__.
+   Don't see your library on this page? `Submit it here <https://jira.mongodb.org/secure/CreateIssueDetails!init.jspa?pid=10380&issuetype=4&priority=4>`__.

--- a/source/includes/important-community-drivers.rst
+++ b/source/includes/important-community-drivers.rst
@@ -1,0 +1,7 @@
+.. important::
+
+   Libraries listed here are not developed, maintained, or supported
+   by MongoDB in any way. They are solely created and supported by
+   the community.
+
+   Don't see your library on this page? `Submit it here <https://jira.mongodb.org/secure/CreateIssueDetails!init.jspa?pid=10380&issuetype=4>`__.


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOP-958

### Design
https://mongodb.invisionapp.com/share/PTVY7JNYUXZ#/screens/404664689

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/8763975/drivers/docsworker-xlarge/DOP-958/community-supported-drivers

### Notes
- We don't yet support striped tables on Docs (to the best of my knowledge), but I added `:class: striped` to the directive to support that styling when it is added.
- I checked all the links to ensure they're not dead