### PR TITLE
Update PHP compatibility tables

### DIFF
--- a/source/includes/language-compatibility-table-php.rst
+++ b/source/includes/language-compatibility-table-php.rst
@@ -14,6 +14,15 @@
      - PHP 5.6
      - PHP 5.5
 
+   * - ext 1.7 + lib 1.6
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     -
+
    * - ext 1.6 + lib 1.5
      - |checkmark|
      - |checkmark|

--- a/source/includes/php-mongodb-compatibility-table.rst
+++ b/source/includes/php-mongodb-compatibility-table.rst
@@ -12,7 +12,7 @@
      - MongoDB 3.0
      - MongoDB 2.6
 
-   * - ext 1.6 + lib 1.5
+   * - ext 1.7 + lib 1.6
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -21,6 +21,14 @@
      - |checkmark|
      -
 
+   * - ext 1.6 + lib 1.5
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     -
 
    * - ext 1.5 + lib 1.4
      -


### PR DESCRIPTION
## Pull Request Info

@akung0324 asked about this in Slack.

PHPC 1.7 and PHPLIB 1.6 were no different from the previous versions, respectively, aside from adding FLE support and I don't believe we track that information in this table.

cc: @alcaeus 