### PR TITLE
DOCSP-10523: add link to golang tutorials

### DIFF
--- a/source/go.txt
+++ b/source/go.txt
@@ -19,8 +19,6 @@ Introduction
 
 This is the official MongoDB Go Driver.
 
-- `Get Started <https://www.mongodb.com/blog/post/mongodb-go-driver-tutorial>`__
-
 - `Quick Start Tutorials <https://www.mongodb.com/blog/search/golang%20quickstart>`__
 
 - `Migration from Community Drivers <https://www.mongodb.com/blog/post/go-migration-guide>`__

--- a/source/go.txt
+++ b/source/go.txt
@@ -19,16 +19,17 @@ Introduction
 
 This is the official MongoDB Go Driver.
 
-- `General documentation for the MongoDB Go Driver <https://godoc.org/go.mongodb.org/mongo-driver/mongo>`__
+- `Get Started with Go <https://www.mongodb.com/blog/post/mongodb-go-driver-tutorial>`__
 
-- `Get Started with Go <https://www.mongodb.com/blog/post/mongodb-go-driver-tutorial>`_
+- `MongoDB Go Driver Quick Start Tutorials <https://www.mongodb.com/blog/search/golang%20quickstart>`__
 
-- `Migration from Community Drivers <https://www.mongodb.com/blog/post/go-migration-guide>`_
+- `Migration from Community Drivers <https://www.mongodb.com/blog/post/go-migration-guide>`__
+
+- `API documentation for the MongoDB Go Driver <https://godoc.org/go.mongodb.org/mongo-driver/mongo>`__
 
 - `Changelog <https://github.com/mongodb/mongo-go-driver/releases>`__
 
 - `Source Code <https://github.com/mongodb/mongo-go-driver>`__
-
 
 Installation
 ------------
@@ -36,14 +37,12 @@ Installation
 The recommended way to get started using the MongoDB Go driver is by using
 `Go modules <https://blog.golang.org/v2-go-modules>`__
 
-
 .. code-block:: go
 
    mkdir goproj
    cd goproj
    go mod init goproj
    go get go.mongodb.org/mongo-driver/mongo
-
 
 See `Installation <https://github.com/mongodb/mongo-go-driver#installation>`__
 

--- a/source/go.txt
+++ b/source/go.txt
@@ -19,13 +19,13 @@ Introduction
 
 This is the official MongoDB Go Driver.
 
-- `Get Started with Go <https://www.mongodb.com/blog/post/mongodb-go-driver-tutorial>`__
+- `Get Started <https://www.mongodb.com/blog/post/mongodb-go-driver-tutorial>`__
 
-- `MongoDB Go Driver Quick Start Tutorials <https://www.mongodb.com/blog/search/golang%20quickstart>`__
+- `Quick Start Tutorials <https://www.mongodb.com/blog/search/golang%20quickstart>`__
 
 - `Migration from Community Drivers <https://www.mongodb.com/blog/post/go-migration-guide>`__
 
-- `API documentation for the MongoDB Go Driver <https://godoc.org/go.mongodb.org/mongo-driver/mongo>`__
+- `API Reference <https://godoc.org/go.mongodb.org/mongo-driver/mongo>`__
 
 - `Changelog <https://github.com/mongodb/mongo-go-driver/releases>`__
 

--- a/source/go.txt
+++ b/source/go.txt
@@ -45,7 +45,7 @@ The recommended way to get started using the MongoDB Go driver is by using
    go get go.mongodb.org/mongo-driver/mongo
 
 See `Installation <https://github.com/mongodb/mongo-go-driver#installation>`__
-
+for additional ways to add the driver to your project.
 
 Connect to MongoDB Atlas
 ------------------------


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-10523

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/0fc41ed/drivers/docsworker/DOCSP-10523-add-golang-tutorials/go/
