### PR TITLE
Rename Community Supported Drivers page template

### DIFF
--- a/source/community-supported-drivers.txt
+++ b/source/community-supported-drivers.txt
@@ -1,5 +1,5 @@
 :orphan:
-:template: landing
+:template: blank
 
 ===================
 Community Libraries


### PR DESCRIPTION
## Pull Request Info
- Change template name from `landing` to `blank` in order to address changes introduced in [snooty@v0.4.12](https://github.com/mongodb/snooty/releases/tag/v0.4.12)

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/934b109/drivers/docsworker-xlarge/rename-template/community-supported-drivers