### PR TITLE
replace api.mongodb.com link for pymongo API docs

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -30,6 +30,7 @@ raw: ecosystem/tutorial/automate-deployment-with-cloudformation -> ${base}/platf
 raw: ecosystem/tutorial/deploy-mongodb-from-aws-marketplace -> ${base}/platforms/amazon-ec2
 raw: ecosystem/tutorial/install-mongodb-on-windows-azure -> ${base}/platforms/windows-azure
 raw: ecosystem/tutorials -> ${base}/tutorial
+raw: ecosystem/drivers -> ${base}
 raw: ecosystem/drivers/javascript -> ${base}/drivers/node-js
 raw: ecosystem/tutorial/download-and-compile-cpp-driver -> https://github.com/mongodb/mongo-cxx-driver/wiki/Download%20and%20Compile
 raw: ecosystem/tutorial/getting-started-with-cpp-driver -> https://github.com/mongodb/mongo-cxx-driver/wiki/blob/legacy/README.md

--- a/config/redirects
+++ b/config/redirects
@@ -30,7 +30,6 @@ raw: ecosystem/tutorial/automate-deployment-with-cloudformation -> ${base}/platf
 raw: ecosystem/tutorial/deploy-mongodb-from-aws-marketplace -> ${base}/platforms/amazon-ec2
 raw: ecosystem/tutorial/install-mongodb-on-windows-azure -> ${base}/platforms/windows-azure
 raw: ecosystem/tutorials -> ${base}/tutorial
-raw: ecosystem/drivers -> ${base}
 raw: ecosystem/drivers/javascript -> ${base}/drivers/node-js
 raw: ecosystem/tutorial/download-and-compile-cpp-driver -> https://github.com/mongodb/mongo-cxx-driver/wiki/Download%20and%20Compile
 raw: ecosystem/tutorial/getting-started-with-cpp-driver -> https://github.com/mongodb/mongo-cxx-driver/wiki/blob/legacy/README.md

--- a/source/includes/driver-table.rst
+++ b/source/includes/driver-table.rst
@@ -67,7 +67,7 @@
    * - :doc:`Python </python>`
      - `Releases <https://pypi.python.org/pypi/pymongo/>`__
      - `Source <https://github.com/mongodb/mongo-python-driver>`__
-     - :api:`API <python/current>`
+     - :api:`API <https://pymongo.readthedocs.io/en/stable/api>`__
      - :issue:`JIRA <PYTHON>`
      - `Course <https://university.mongodb.com/courses/M220P/about>`__
 

--- a/source/includes/driver-table.rst
+++ b/source/includes/driver-table.rst
@@ -67,7 +67,7 @@
    * - :doc:`Python </python>`
      - `Releases <https://pypi.python.org/pypi/pymongo/>`__
      - `Source <https://github.com/mongodb/mongo-python-driver>`__
-     - :api:`API <https://pymongo.readthedocs.io/en/stable/api>`__
+     - `API <https://pymongo.readthedocs.io/en/stable/api>`__
      - :issue:`JIRA <PYTHON>`
      - `Course <https://university.mongodb.com/courses/M220P/about>`__
 


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
Additional fix for https://jira.mongodb.org/browse/DOCS-13677

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/a6cf9cc/drivers/docsworker/060920-drivers-page-python-api-link/drivers
