### PR TITLE
Update PHP language compat table

### DIFF
--- a/source/includes/language-compatibility-table-php.rst
+++ b/source/includes/language-compatibility-table-php.rst
@@ -14,6 +14,15 @@
      - PHP 5.6
      - PHP 5.5
 
+   * - ext 1.8 + lib 1.7
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     -
+     -
+
    * - ext 1.7 + lib 1.6
      - |checkmark|
      - |checkmark|


### PR DESCRIPTION
@ccho-mongodb: This adds the 4.4-compat release and complements https://github.com/mongodb/docs-ecosystem/pull/653. Notable change is that we dropped support for PHP 5.x.