### PR TITLE
DOCSP-11098 fix csfle python

### DIFF
--- a/source/use-cases/client-side-field-level-encryption-guide.txt
+++ b/source/use-cases/client-side-field-level-encryption-guide.txt
@@ -1017,7 +1017,7 @@ clients without CSFLE enabled could not read the encrypted data.
 Additional Information
 ----------------------
 
-.. _download-example-project
+.. _download-example-project:
 
 Download Example Project
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/use-cases/client-side-field-level-encryption-guide.txt
+++ b/source/use-cases/client-side-field-level-encryption-guide.txt
@@ -27,7 +27,7 @@ information in the context of a real-world scenario:
 .. admonition:: Download the Code
 
    For a runnable example of all the functionality demonstrated in this guide,
-   see the `Download Example Project`_ section.
+   see the :ref:`Download Example Project <download-example-project>` section.
 
 Introduction
 ------------
@@ -1016,6 +1016,8 @@ clients without CSFLE enabled could not read the encrypted data.
 
 Additional Information
 ----------------------
+
+.. _download-example-project
 
 Download Example Project
 ~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-11098

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/bdd0989/drivers/docsworker-xlarge/DOCSP-11098-fix-csfle-python/use-cases/client-side-field-level-encryption-guide

- Fixed the anchor link.
- Verified that the python example still works as expected.
