### PR TITLE
DOCSP-11544: update Java landing pages for 4.1

### DIFF
--- a/source/includes/atlas-connect-blurb.rst
+++ b/source/includes/atlas-connect-blurb.rst
@@ -1,3 +1,3 @@
 
 To connect to a :atlas:`MongoDB Atlas <>` cluster, use the
-:atlas:`Atlas connection string <driver-connection>` for your cluster:
+:atlas:`Atlas connection string </driver-connection>` for your cluster:

--- a/source/includes/help-links-java.rst
+++ b/source/includes/help-links-java.rst
@@ -3,4 +3,4 @@ How to get help
 
 - Ask questions on our :community-forum:`MongoDB Community Forums <>`.
 - Visit our :technical-support:`Support Channels </>`.
-- See :java-docs:`Issues & Help <issues-help/>`.
+- See `Issues & Help <https://mongodb.github.io/mongo-java-driver/4.1/issues-help/>`__.

--- a/source/java.txt
+++ b/source/java.txt
@@ -19,13 +19,13 @@ Introduction
 
 The official MongoDB Java Driver providing both synchronous and asynchronous interaction with MongoDB.
 
-- :java-docs:`Tutorials <driver/tutorials/>`
+- `Reference Documentation <https://mongodb.github.io/mongo-java-driver/4.1/driver/>`__
 
-- :java-docs:`Usage Guide <driver/>`
+- `Tutorials <https://mongodb.github.io/mongo-java-driver/4.1/driver/tutorials/>`__
 
-- :java-docs:`API Documentation <apidocs/>`
+- `API Documentation <https://mongodb.github.io/mongo-java-driver/4.1/apidocs/>`__
 
-- :java-docs:`Changelog <whats-new/>`
+- `What's New <https://mongodb.github.io/mongo-java-driver/4.1/whats-new/>`__
 
 - `Source Code <https://github.com/mongodb/mongo-java-driver/>`__
 
@@ -47,8 +47,8 @@ Installation
 ------------
 
 The recommended way to get started using one of the drivers in your project is with a dependency
-management system. See
-:java-docs:`Installation Guide <driver/getting-started/installation/>`
+management system. See the `Installation Guide <https://mongodb.github.io/mongo-java-driver/4.1/driver/getting-started/installation/>`__
+for more information.
 
 
 Connect to MongoDB Atlas
@@ -75,8 +75,7 @@ Connect to MongoDB Atlas
    MongoClient mongoClient = MongoClients.create(settings);
    MongoDatabase database = mongoClient.getDatabase("test");
 
-
-See :java-docs:`Connect to MongoDB <driver/tutorials/connect-to-mongodb/>`
+See `Connect to MongoDB <https://mongodb.github.io/mongo-java-driver/4.1/driver/tutorials/connect-to-mongodb/>`__
 for more ways to connect.
 
 

--- a/source/reactive-streams.txt
+++ b/source/reactive-streams.txt
@@ -18,17 +18,13 @@ Introduction
 **Java Reactive Streams** is an official Java driver for MongoDB and is the
 recommended driver for working with reactive streams in the JVM ecosystem.
 
-- `Tutorials
-  <http://mongodb.github.io/mongo-java-driver/4.0/driver-reactive/tutorials/>`_
+- `Reference Documentation <https://mongodb.github.io/mongo-java-driver/4.1/driver-reactive/>`__
 
-- `Usage Guide
-  <http://mongodb.github.io/mongo-java-driver/4.0/driver-reactive/>`_
+- `Tutorials <https://mongodb.github.io/mongo-java-driver/4.1/driver-reactive/tutorials/>`__
 
-- `API Reference
-  <https://mongodb.github.io/mongo-java-driver-reactivestreams/1.13/javadoc/>`_
+- `API Reference <https://mongodb.github.io/mongo-java-driver/4.1/apidocs/mongodb-driver-reactivestreams/index.html>`__
 
-- `Changelog
-  <https://mongodb.github.io/mongo-java-driver-reactivestreams/1.13/changelog/>`_
+- `What's New <https://mongodb.github.io/mongo-java-driver/4.1/whats-new/>`__
 
 - `Source Code
   <https://github.com/mongodb/mongo-java-driver-reactivestreams/>`_
@@ -38,8 +34,7 @@ Installation
 
 The recommended way to get started using the driver in your project is with
 a dependency management system.
-See the `Installation Guide
-<http://mongodb.github.io/mongo-java-driver-reactivestreams/1.13/getting-started/installation-guide/>`_
+See the `Installation Guide <https://mongodb.github.io/mongo-java-driver/4.1/driver-reactive/getting-started/installation/>`__
 for more information.
 
 Connect to MongoDB Atlas
@@ -66,8 +61,7 @@ Connect to MongoDB Atlas
    MongoClient mongoClient = MongoClients.create(settings);
    MongoDatabase database = mongoClient.getDatabase("test");
 
-See `Connect to MongoDB
-<http://mongodb.github.io/mongo-java-driver/4.0/driver-reactive/tutorials/>`_
+See `Connect to MongoDB <https://mongodb.github.io/mongo-java-driver/4.1/driver-reactive/tutorials/connect-to-mongodb/>`__
 for more ways to connect.
 
 Compatibility

--- a/source/reactive-streams.txt
+++ b/source/reactive-streams.txt
@@ -22,7 +22,7 @@ recommended driver for working with reactive streams in the JVM ecosystem.
 
 - `Tutorials <https://mongodb.github.io/mongo-java-driver/4.1/driver-reactive/tutorials/>`__
 
-- `API Reference <https://mongodb.github.io/mongo-java-driver/4.1/apidocs/mongodb-driver-reactivestreams/index.html>`__
+- `API Documentation <https://mongodb.github.io/mongo-java-driver/4.1/apidocs/mongodb-driver-reactivestreams/index.html>`__
 
 - `What's New <https://mongodb.github.io/mongo-java-driver/4.1/whats-new/>`__
 

--- a/source/scala.txt
+++ b/source/scala.txt
@@ -21,13 +21,14 @@ This is the officially supported Scala driver for MongoDB.
 
 It's a modern idiomatic Scala driver with asynchronous and non-blocking IO.
 
-- :scala-docs:`Getting Started </getting-started/>`
 
-- :scala-docs:`Usage Guide </reference/>`
+- `Reference Documentation <http://mongodb.github.io/mongo-java-driver/4.1/driver-scala/>`__
+  
+- `Tutorials <http://mongodb.github.io/mongo-java-driver/4.1/driver-scala/tutorials/>`__
 
-- :scala-docs:`API Reference </scaladoc/>`
+- `API Documentation <http://mongodb.github.io/mongo-java-driver/4.1/apidocs/>`__
 
-- :scala-docs:`Changelog </changelog/>`
+- `What's New <https://mongodb.github.io/mongo-java-driver/4.1/whats-new/>`__
 
 - `Source Code <http://github.com/mongodb/mongo-scala-driver>`__
 
@@ -37,7 +38,7 @@ Installation
 
 The recommended way to get started using the driver in your project is
 with a dependency management system like ``sbt`` or ``maven``. See the
-:scala-docs:`Installation Guide </getting-started/installation-guide/>`
+`Installation Guide <http://mongodb.github.io/mongo-java-driver/4.1/driver-scala/getting-started/installation/>`__
 for more information.
 
 
@@ -58,8 +59,8 @@ Connect to MongoDB Atlas
    val db: MongoDatabase = client.getDatabase("test")
 
 
-See our guide on :scala-docs:`Connecting </reference/connecting>` for more 
-ways to connect.
+See our guide on `Connecting <http://mongodb.github.io/mongo-java-driver/4.1/driver-scala/tutorials/connect-to-mongodb/>`__ 
+for more ways to connect.
 
 
 Compatibility


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-11544

### Docs staging link (requires sign-in on MongoDB Corp SSO):
[Java](https://docs-mongodbcom-staging.corp.mongodb.com/3eaeede/drivers/docsworker-xlarge/DOCSP-11544-java-landing-updates/java/)
[Reactive Streams](https://docs-mongodbcom-staging.corp.mongodb.com/3eaeede/drivers/docsworker-xlarge/DOCSP-11544-java-landing-updates/reactive-streams/)
[Scala](https://docs-mongodbcom-staging.corp.mongodb.com/3eaeede/drivers/docsworker-xlarge/DOCSP-11544-java-landing-updates/scala/)