### PR TITLE
Rewrite Doctrine MongoDB ODM chapter

### DIFF
--- a/source/php-libraries.txt
+++ b/source/php-libraries.txt
@@ -82,14 +82,10 @@ Stand-alone Libraries
 ~~~~~~~~~~~~~~~~~~~~~
 
 - `Doctrine MongoDB ODM <https://github.com/doctrine/mongodb-odm>`_ is a library
-  that provides a PHP object mapping functionality for MongoDB. An underlying
-  `MongoDB abstraction layer <https://github.com/doctrine/mongodb>`_ exists as
-  a separate project. A `Symfony bundle
+  that provides a PHP object mapping functionality for MongoDB. A `Symfony bundle
   <https://github.com/doctrine/DoctrineMongoDBBundle>`_ and `Zend Framework
   module <https://github.com/doctrine/DoctrineMongoODMModule>`_ for the ODM are
-  also available. Although it is written for the legacy ``mongo`` extension, it
-  is tested to work with the ``mongodb`` extension using `Mongo PHP Adapter
-  <https://github.com/alcaeus/mongo-php-adapter>`_.
+  also available.
 
 - `Mongator ODM <https://github.com/mongator/mongator/>`_ is an easy, powerful,
   and ultrafast ODM for PHP and MongoDB. It is a fork of the


### PR DESCRIPTION
With a recent release, Doctrine MongoDB ODM dropped usage of the legacy PHP driver in favour of the current driver. Information regarding compatibility libraries has been removed.