### PR TITLE
DOCSP-10572: remove c++ 3.5 from server 4.2 compat

### DIFF
--- a/source/includes/mongodb-compatibility-table-cxx.rst
+++ b/source/includes/mongodb-compatibility-table-cxx.rst
@@ -28,7 +28,7 @@
 
    * - mongocxx 3.5
      -
-     - |checkmark|
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-10572

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/3ce6fc7/drivers/docsworker-xlarge/DOCSP-10572-cxx-matrix-update/cxx
