### PR TITLE
DOCSP-12465 rust connection examples

### DIFF
--- a/source/rust.txt
+++ b/source/rust.txt
@@ -47,13 +47,20 @@ corresponding connection code samples.
    .. tab:: Sync
       :tabid: rust-sync
 
+
+      Make sure you set ``default-features=false`` and enabled the
+      ``sync`` feature in your ``Cargo.toml`` file.
+      
+      Make sure you enabled the sync API. See
+      `Enabling the sync API <https://github.com/mongodb/mongo-rust-driver#enabling-the-sync-api>`__
+      for more details.
+
       .. code-block:: rust
 
-         // Be sure to set default-features=false and enable the "sync" feature in your Cargo.toml
          use mongodb::{bson::doc, sync::Client};
 
          fn main() -> mongodb::error::Result<()> {
-             // Get a handle to the deployment.
+             // Get a handle to the cluster
              let client = Client::with_uri_str(
                  "mongodb+srv://<username>:<password>@<cluster-url>/test?w=majority",
              )?;
@@ -63,7 +70,7 @@ corresponding connection code samples.
                  .run_command(doc! {"ping": 1}, None)?;
              println!("Connected successfully.");
 
-             // List the names of the databases in that deployment.
+             // List the names of the databases in that cluster
              for db_name in client.list_database_names(None, None)? {
                  println!("{}", db_name);
              }
@@ -73,21 +80,25 @@ corresponding connection code samples.
    .. tab:: Async
       :tabid: rust-async
 
+      Make sure you specified your async runtime. See
+      `Configuring the async runtime <https://github.com/mongodb/mongo-rust-driver#configuring-the-async-runtime>`__
+      for more details.
+      
       .. code-block:: rust
 
          use mongodb::{bson::doc, options::ClientOptions, Client};
 
          #[tokio::main]
          async fn main() -> mongodb::error::Result<()> {
-             // Parse a connection string into an options struct.
+             // Parse your connection string into an options struct
              let mut client_options =
                  ClientOptions::parse("mongodb+srv://<username>:<password>@<cluster-url>/test?w=majority")
                      .await?;
 
-             // Manually set an option.
+             // Manually set an option
              client_options.app_name = Some("Rust Demo".to_string());
 
-             // Get a handle to the deployment.
+             // Get a handle to the cluster
              let client = Client::with_options(client_options)?;
 
              client
@@ -96,7 +107,7 @@ corresponding connection code samples.
                  .await?;
              println!("Connected successfully.");
 
-             // List the names of the databases in that deployment.
+             // List the names of the databases in that cluster
              for db_name in client.list_database_names(None, None).await? {
                  println!("{}", db_name);
              }

--- a/source/rust.txt
+++ b/source/rust.txt
@@ -37,9 +37,73 @@ See `Installation <https://github.com/mongodb/mongo-rust-driver#Installation>`__
 Connect to MongoDB Atlas
 ------------------------
 
+Select from the :guilabel:`Sync` or :guilabel:`Async` tabs below for
+corresponding connection code samples.
+
 .. include:: /includes/atlas-connect-blurb.rst
 
-.. code-block:: rust
+.. tabs::
+
+   .. tab:: Sync
+      :tabid: rust-sync
+
+      .. code-block:: rust
+
+         // Be sure to set default-features=false and enable the "sync" feature in your Cargo.toml
+         use mongodb::{bson::doc, sync::Client};
+
+         fn main() -> mongodb::error::Result<()> {
+             // Get a handle to the deployment.
+             let client = Client::with_uri_str(
+                 "mongodb+srv://<username>:<password>@<cluster-url>/test?w=majority",
+             )?;
+
+             client
+                 .database("admin")
+                 .run_command(doc! {"ping": 1}, None)?;
+             println!("Connected successfully.");
+
+             // List the names of the databases in that deployment.
+             for db_name in client.list_database_names(None, None)? {
+                 println!("{}", db_name);
+             }
+             Ok(())
+         }
+
+   .. tab:: Async
+      :tabid: rust-async
+
+      .. code-block:: rust
+
+         use mongodb::{bson::doc, options::ClientOptions, Client};
+
+         #[tokio::main]
+         async fn main() -> mongodb::error::Result<()> {
+             // Parse a connection string into an options struct.
+             let mut client_options =
+                 ClientOptions::parse("mongodb+srv://<username>:<password>@<cluster-url>/test?w=majority")
+                     .await?;
+
+             // Manually set an option.
+             client_options.app_name = Some("Rust Demo".to_string());
+
+             // Get a handle to the deployment.
+             let client = Client::with_options(client_options)?;
+
+             client
+                 .database("admin")
+                 .run_command(doc! {"ping": 1}, None)
+                 .await?;
+             println!("Connected successfully.");
+
+             // List the names of the databases in that deployment.
+             for db_name in client.list_database_names(None, None).await? {
+                 println!("{}", db_name);
+             }
+             Ok(())
+         }
+
+
 
    use bson::doc;
    use mongodb::{options::ClientOptions, Client};

--- a/source/rust.txt
+++ b/source/rust.txt
@@ -103,34 +103,6 @@ corresponding connection code samples.
              Ok(())
          }
 
-
-
-   use bson::doc;
-   use mongodb::{options::ClientOptions, Client};
-
-   fn main() -> mongodb::error::Result<()> {
-       // Parse a connection string into an options struct.
-       let mut client_options =
-           ClientOptions::parse("mongodb+srv://<username>:<password>@<cluster-url>/test?w=majority")?;
-
-       // Manually set an option.
-       client_options.app_name = Some("Rust Demo".to_string());
-
-       // Get a handle to the deployment.
-       let client = Client::with_options(client_options)?;
-
-       client
-           .database("admin")
-           .run_command(doc! {"ping": 1}, None)?;
-       println!("Connected successfully.");
-
-       // List the names of the databases in that deployment.
-       for db_name in client.list_database_names(None)? {
-           println!("{}", db_name);
-       }
-       Ok(())
-   }
-
 Compatibility
 -------------
 

--- a/source/rust.txt
+++ b/source/rust.txt
@@ -47,10 +47,6 @@ corresponding connection code samples.
    .. tab:: Sync
       :tabid: rust-sync
 
-
-      Make sure you set ``default-features=false`` and enabled the
-      ``sync`` feature in your ``Cargo.toml`` file.
-      
       Make sure you enabled the sync API. See
       `Enabling the sync API <https://github.com/mongodb/mongo-rust-driver#enabling-the-sync-api>`__
       for more details.
@@ -83,7 +79,7 @@ corresponding connection code samples.
       Make sure you specified your async runtime. See
       `Configuring the async runtime <https://github.com/mongodb/mongo-rust-driver#configuring-the-async-runtime>`__
       for more details.
-      
+
       .. code-block:: rust
 
          use mongodb::{bson::doc, options::ClientOptions, Client};

--- a/source/rust.txt
+++ b/source/rust.txt
@@ -44,41 +44,12 @@ corresponding connection code samples.
 
 .. tabs::
 
-   .. tab:: Sync
-      :tabid: rust-sync
-
-      Make sure you enabled the sync API. See
-      `Enabling the sync API <https://github.com/mongodb/mongo-rust-driver#enabling-the-sync-api>`__
-      for more details.
-
-      .. code-block:: rust
-
-         use mongodb::{bson::doc, sync::Client};
-
-         fn main() -> mongodb::error::Result<()> {
-             // Get a handle to the cluster
-             let client = Client::with_uri_str(
-                 "mongodb+srv://<username>:<password>@<cluster-url>/test?w=majority",
-             )?;
-
-             client
-                 .database("admin")
-                 .run_command(doc! {"ping": 1}, None)?;
-             println!("Connected successfully.");
-
-             // List the names of the databases in that cluster
-             for db_name in client.list_database_names(None, None)? {
-                 println!("{}", db_name);
-             }
-             Ok(())
-         }
-
    .. tab:: Async
       :tabid: rust-async
 
-      Make sure you specified your async runtime. See
-      `Configuring the async runtime <https://github.com/mongodb/mongo-rust-driver#configuring-the-async-runtime>`__
-      for more details.
+      The default async runtime used by the driver is ``tokio``. To use a
+      different runtime, see
+      `Configuring the async runtime <https://github.com/mongodb/mongo-rust-driver#configuring-the-async-runtime>`__.
 
       .. code-block:: rust
 
@@ -97,6 +68,7 @@ corresponding connection code samples.
              // Get a handle to the cluster
              let client = Client::with_options(client_options)?;
 
+             // Ping the server to see if you can connect to the cluster
              client
                  .database("admin")
                  .run_command(doc! {"ping": 1}, None)
@@ -105,6 +77,36 @@ corresponding connection code samples.
 
              // List the names of the databases in that cluster
              for db_name in client.list_database_names(None, None).await? {
+                 println!("{}", db_name);
+             }
+             Ok(())
+         }
+
+   .. tab:: Sync
+      :tabid: rust-sync
+
+      Make sure you enabled the sync API. See
+      `Enabling the sync API <https://github.com/mongodb/mongo-rust-driver#enabling-the-sync-api>`__
+      for more details.
+
+      .. code-block:: rust
+
+         use mongodb::{bson::doc, sync::Client};
+
+         fn main() -> mongodb::error::Result<()> {
+             // Get a handle to the cluster
+             let client = Client::with_uri_str(
+                 "mongodb+srv://<username>:<password>@<cluster-url>/test?w=majority",
+             )?;
+
+             // Ping the server to see if you can connect to the cluster
+             client
+                 .database("admin")
+                 .run_command(doc! {"ping": 1}, None)?;
+             println!("Connected successfully.");
+
+             // List the names of the databases in that cluster
+             for db_name in client.list_database_names(None, None)? {
                  println!("{}", db_name);
              }
              Ok(())


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-12465

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodborg-staging.corp.mongodb.com/506eafa/drivers/docsworker-xlarge/DOCSP-12465-rust-connection-examples/rust/#connect-to-mongodb-atlas
