### PR TITLE
DOP-931: Name footnotes in included files

### DIFF
--- a/source/includes/language-compatibility-table-java-rs.rst
+++ b/source/includes/language-compatibility-table-java-rs.rst
@@ -7,7 +7,7 @@
      - Java 6
      - Java 7
      - Java 8
-     - Java 11 [#language-compatibility-rs]_
+     - Java 11 [#backwards-compatible-rs]_
 
    * - 1.13
      - |checkmark|
@@ -81,4 +81,4 @@
      - |checkmark|
      - |checkmark|
 
-.. [#language-compatibility-rs] Java versions 8 and above are all supported thanks to the JVM backwards compatibility promise. Only LTS versions will be explicitly listed in future.
+.. [#backwards-compatible-rs] Java versions 8 and above are all supported thanks to the JVM backwards compatibility promise. Only LTS versions will be explicitly listed in future.

--- a/source/includes/language-compatibility-table-java-rs.rst
+++ b/source/includes/language-compatibility-table-java-rs.rst
@@ -7,7 +7,7 @@
      - Java 6
      - Java 7
      - Java 8
-     - Java 11 [*]_
+     - Java 11 [#language-compatibility-rs]_
 
    * - 1.13
      - |checkmark|
@@ -81,4 +81,4 @@
      - |checkmark|
      - |checkmark|
 
-.. [*] Java versions 8 and above are all supported thanks to the JVM backwards compatibility promise. Only LTS versions will be explicitly listed in future.
+.. [#language-compatibility-rs] Java versions 8 and above are all supported thanks to the JVM backwards compatibility promise. Only LTS versions will be explicitly listed in future.

--- a/source/includes/language-compatibility-table-java.rst
+++ b/source/includes/language-compatibility-table-java.rst
@@ -8,7 +8,7 @@
      - Java 6
      - Java 7
      - Java 8
-     - Java 11 [#language-compatibility]_
+     - Java 11 [#backwards-compatible]_
 
    * - Version 4.0
      -
@@ -95,4 +95,4 @@
      - |checkmark|
 
 
-.. [#language-compatibility] Java versions 8 and above are all supported thanks to the JVM backwards compatibility promise. Only LTS versions will be explicitly listed in future.
+.. [#backwards-compatible] Java versions 8 and above are all supported thanks to the JVM backwards compatibility promise. Only LTS versions will be explicitly listed in future.

--- a/source/includes/language-compatibility-table-java.rst
+++ b/source/includes/language-compatibility-table-java.rst
@@ -8,7 +8,7 @@
      - Java 6
      - Java 7
      - Java 8
-     - Java 11 [*]_
+     - Java 11 [#language-compatibility]_
 
    * - Version 4.0
      -
@@ -94,4 +94,5 @@
      - |checkmark|
      - |checkmark|
 
-.. [*] Java versions 8 and above are all supported thanks to the JVM backwards compatibility promise. Only LTS versions will be explicitly listed in future.
+
+.. [#language-compatibility] Java versions 8 and above are all supported thanks to the JVM backwards compatibility promise. Only LTS versions will be explicitly listed in future.

--- a/source/includes/mongodb-compatibility-table-java.rst
+++ b/source/includes/mongodb-compatibility-table-java.rst
@@ -174,7 +174,7 @@
      -
      -
      -
-     - |checkmark|  [#mongodb-compatibility]_
+     - |checkmark|  [#driver-support]_
      - |checkmark|
      - |checkmark|
 
@@ -198,7 +198,7 @@
      -
      - |checkmark|
 
-.. [#mongodb-compatibility] The 2.14 driver does not support all MongoDB 3.2 features (e.g.,
+.. [#driver-support] The 2.14 driver does not support all MongoDB 3.2 features (e.g.,
    read concern); however, if you are currently on a version 2.x driver
    and would like to run against MongoDB 3.2 but cannot upgrade to driver
    version 3.2, use the 2.14 driver.

--- a/source/includes/mongodb-compatibility-table-java.rst
+++ b/source/includes/mongodb-compatibility-table-java.rst
@@ -174,7 +174,7 @@
      -
      -
      -
-     - |checkmark|  [*]_
+     - |checkmark|  [#mongodb-compatibility]_
      - |checkmark|
      - |checkmark|
 
@@ -197,3 +197,8 @@
      -
      -
      - |checkmark|
+
+.. [#mongodb-compatibility] The 2.14 driver does not support all MongoDB 3.2 features (e.g.,
+   read concern); however, if you are currently on a version 2.x driver
+   and would like to run against MongoDB 3.2 but cannot upgrade to driver
+   version 3.2, use the 2.14 driver.

--- a/source/java.txt
+++ b/source/java.txt
@@ -89,11 +89,6 @@ MongoDB Compatibility
 
 .. include:: /includes/older-server-versions-unsupported.rst
 
-.. [*] The 2.14 driver does not support all MongoDB 3.2 features (e.g.,
-   read concern); however, if you are currently on a version 2.x driver
-   and would like to run against MongoDB 3.2 but cannot upgrade to driver
-   version 3.2, use the 2.14 driver.
-
 Language Compatibility
 ~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
## Pull Request Info
Anonymous footnotes spread across multiple include files are problematic. To maintain sanity, it's helpful to name the footnotes and footnote references so that the backend can match them up.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOP-931

### With this change:
https://docs-mongodborg-staging.corp.mongodb.com/DOP-931/drivers/cgoecknerwald/master/

### Without this change:
https://docs-mongodborg-staging.corp.mongodb.com/master/drivers/cgoecknerwald/master/


