### PR TITLE
DOCS-13936: update csharp links for 2.11 driver

### DIFF
--- a/source/csharp.txt
+++ b/source/csharp.txt
@@ -20,13 +20,13 @@ Introduction
 The official MongoDB C#/.NET Driver provides asynchronous interaction
 with MongoDB.
 
-- `Getting Started <https://mongodb.github.io/mongo-csharp-driver/2.10/getting_started/>`_
+- `Getting Started <https://mongodb.github.io/mongo-csharp-driver/2.11/getting_started/>`__
 
-- `API Reference <https://mongodb.github.io/mongo-csharp-driver/2.10/apidocs/html/R_Project_CSharpDriverDocs.htm>`_
+- `API Reference <https://mongodb.github.io/mongo-csharp-driver/2.11/apidocs/html/R_Project_CSharpDriverDocs.htm>`__
 
-- `Changelog <https://mongodb.github.io/mongo-csharp-driver/2.10/what_is_new/>`_
+- `Changelog <https://mongodb.github.io/mongo-csharp-driver/2.11/what_is_new/>`__
 
-- `Source Code <https://github.com/mongodb/mongo-csharp-driver>`_
+- `Source Code <https://github.com/mongodb/mongo-csharp-driver>`__
 
 Take the free online course taught by MongoDB
 ---------------------------------------------
@@ -43,11 +43,10 @@ Installation
 ------------
 
 ``NuGet`` is the simplest way to get the driver. Use
-`MongoDB.Driver <http://www.nuget.org/packages/mongodb.driver>`_ for
+`MongoDB.Driver <http://www.nuget.org/packages/mongodb.driver>`__ for
 all new projects.
 
-For more information, see `Installation
-<https://mongodb.github.io/mongo-csharp-driver/2.10/getting_started/installation/>`_.
+For more information, see `Installation <https://mongodb.github.io/mongo-csharp-driver/2.11/getting_started/installation/>`__.
 
 
 Connect to MongoDB Atlas
@@ -66,7 +65,7 @@ Connect to MongoDB Atlas
    var database = client.GetDatabase("test");
 
 
-See `Connecting <https://mongodb.github.io/mongo-csharp-driver/2.10/reference/driver/connecting/>`__
+See `Connecting <https://mongodb.github.io/mongo-csharp-driver/2.11/reference/driver/connecting/>`__
 for more information.
 
 
@@ -88,3 +87,4 @@ Language Compatibility
 .. include:: /includes/about-driver-compatibility.rst
 
 .. include:: /includes/help-links-csharp.rst
+

--- a/source/includes/language-compatibility-table-csharp.rst
+++ b/source/includes/language-compatibility-table-csharp.rst
@@ -17,6 +17,19 @@
      - .NET Core 3.0
      - .NET Core 3.1
 
+   * - Version 2.11
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+
    * - Version 2.10
      - |checkmark|
      - |checkmark|


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCS-13936

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/e597ad6/drivers/docsworker-xlarge/DOCS-13936-update-csharp-links/csharp
