### PR TITLE
DOCSP-12976: remove aws region from KMS options

### DIFF
--- a/source/includes/steps-fle-convert-to-a-remote-master-key.yaml
+++ b/source/includes/steps-fle-convert-to-a-remote-master-key.yaml
@@ -57,7 +57,6 @@ content: |
         .. code-block:: java
            :emphasize-lines: 7-9, 11
 
-           BsonString masterKeyRegion = new BsonString("<Master Key AWS Region>"); // e.g. "us-east-2"
            BsonString awsAccessKeyId = new BsonString("<IAM User Access Key ID>");
            BsonString awsSecretAccessKey = new BsonString("<IAM User Secret Access Key>");
            Map<String, Map<String, Object>> kmsProviders = new HashMap<String, Map<String, Object>>();
@@ -65,7 +64,6 @@ content: |
 
            providerDetails.put("accessKeyId", awsAccessKeyId);
            providerDetails.put("secretAccessKey", awsSecretAccessKey);
-           providerDetails.put("region", masterKeyRegion);
 
            kmsProviders.put("aws", providerDetails);
      .. tab::
@@ -104,8 +102,7 @@ content: |
   in the remote KMS. The original data encryption key was encrypted by
   your locally-managed master key.
 
-  Specify the AWS region and `Amazon Resource Number
-  <https://docs.aws.amazon.com/kms/latest/developerguide/viewing-keys.html#find-cmk-id-arn>`_
+  Specify the `Amazon Resource Number <https://docs.aws.amazon.com/kms/latest/developerguide/viewing-keys.html#find-cmk-id-arn>`_
   (ARN) of the new CMK in the CSFLE-enabled client settings. Use the client
   to create a new data encryption key as follows:
 
@@ -128,11 +125,9 @@ content: |
                .kmsProviders(kmsProviders)
                .build());
 
-           BsonString masterKeyRegion = new BsonString("<Master Key AWS Region>"); // e.g. "us-east-2"
            BsonString masterKeyArn = new BsonString("<Master Key ARN>"); // e.g. "arn:aws:kms:us-east-2:111122223333:alias/test-key"
            DataKeyOptions dataKeyOptions = new DataKeyOptions().masterKey(
                new BsonDocument()
-                   .append("region", masterKeyRegion)
                    .append("key", masterKeyArn));
 
            BsonBinary dataKeyId = clientEncryption.createDataKey("aws", dataKeyOptions);
@@ -151,7 +146,6 @@ content: |
            const key = await encryption.createDataKey('aws', {
               masterKey: {
                 key: '<Master Key ARN>', // e.g. 'arn:aws:kms:us-east-2:111122223333:alias/test-key'
-                region: '<Master Key AWS Region>', // e.g. 'us-east-1'
               }
            });
 

--- a/source/includes/steps-fle-convert-to-a-remote-master-key.yaml
+++ b/source/includes/steps-fle-convert-to-a-remote-master-key.yaml
@@ -55,7 +55,6 @@ content: |
         :tabid: java-sync
 
         .. code-block:: java
-           :emphasize-lines: 7-9, 11
 
            BsonString awsAccessKeyId = new BsonString("<IAM User Access Key ID>");
            BsonString awsSecretAccessKey = new BsonString("<IAM User Secret Access Key>");
@@ -115,7 +114,6 @@ content: |
         :tabid: java-sync
 
         .. code-block:: Java
-           :emphasize-lines: 9-14, 16-17
 
            ClientEncryption clientEncryption = ClientEncryptions.create(ClientEncryptionSettings.builder()
                .keyVaultMongoClientSettings(MongoClientSettings.builder()

--- a/source/security/client-side-field-level-encryption-local-key-to-kms.txt
+++ b/source/security/client-side-field-level-encryption-local-key-to-kms.txt
@@ -57,7 +57,7 @@ Convert to a Remote Master Key
    Failure to decrypt all data at this stage may cause permanent and
    unrecoverable data loss.
 
-This following steps explain the setup and updates necessary to move from
+The following steps explain the setup and updates necessary to move from
 a local key provider to AWS KMS.
 
 .. include:: /includes/steps/fle-convert-to-a-remote-master-key.rst

--- a/source/use-cases/client-side-field-level-encryption-guide.txt
+++ b/source/use-cases/client-side-field-level-encryption-guide.txt
@@ -248,7 +248,7 @@ Additional Dependencies
              <https://pypi.org/project/pymongocrypt/>`_
            - Python wrapper for the ``libmongocrypt`` encryption library.
 
-.. _fle-create-a-master-key:
+.. _fle-create-a-master-key-old:
 
 A. Create a Master Key
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -381,7 +381,7 @@ locally-managed master key.
 
 .. include:: /includes/steps/fle-create-data-encryption-key.rst
 
-.. _fle-define-a-json-schema:
+.. _fle-define-a-json-schema-old:
 
 C. Specify Encrypted Fields Using JSON Schema
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1015,7 +1015,7 @@ clients without CSFLE enabled could not read the encrypted data.
 Additional Information
 ----------------------
 
-.. _download-example-project:
+.. _download-example-project-old:
 
 Download Example Project
 ~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-12976

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/df4a744/drivers/docsworker-xlarge/DOCSP-12796-remove-region-aws/security/client-side-field-level-encryption-local-key-to-kms
