### PR TITLE
GCP dotnet info

### DIFF
--- a/source/includes/steps-fle-convert-to-a-remote-master-key-azure.yaml
+++ b/source/includes/steps-fle-convert-to-a-remote-master-key-azure.yaml
@@ -101,7 +101,7 @@ content: |
 
         .. note::
 
-           The Node.js driver does not currently support for Azure KMS.
+           The Node.js driver does not currently support Azure KMS.
 
      .. tab::
         :tabid: python
@@ -220,8 +220,7 @@ content: |
 
         .. note::
 
-           Node does not currently support Azure as a remote KMS.
-
+           The Node.js driver does not currently support Azure KMS.
 
      .. tab::
         :tabid: python

--- a/source/includes/steps-fle-convert-to-a-remote-master-key-gcp.yaml
+++ b/source/includes/steps-fle-convert-to-a-remote-master-key-gcp.yaml
@@ -109,16 +109,9 @@ content: |
      .. tab::
         :tabid: nodejs
 
-        .. code-block:: javascript
+        .. note::
 
-           // TODO: check correctness
-           kmsProviders = {
-             gcp: {
-               email: '<GCP service account email>',
-               privateKey: '<GCP service account private key>',
-               endpoint: '<GCP authentication endpoint>',
-             }
-           }
+           The Node.js driver does not currently support GCP KMS.
 
      .. tab::
         :tabid: python
@@ -132,6 +125,28 @@ content: |
                    "endpoint": "<GCP authentication endpoint>",
                }
            }
+
+     .. tab::
+        :tabid: csharp
+
+        .. code-block:: csharp
+
+           var kmsProviders = new Dictionary<string, IReadOnlyDictionary<string, object>>();
+
+           var gcpPrivateKey = Environment.GetEnvironmentVariable("FLE_GCP_PRIVATE_KEY");
+           var gcpEmail = Environment.GetEnvironmentVariable("FLE_GCP_EMAIL");
+           var gcpEndpoint = Environment.GetEnvironmentVariable("FLE_GCP_IDENTITY_ENDPOINT"); // Optional, defaults to "oauth2.googleapis.com".
+           var gcpKmsOptions = new Dictionary<string, object>
+           {
+               { "privateKey", gcpPrivateKey },
+               { "email", gcpEmail },
+           };
+           if (gcpEndpoint != null)
+           {
+               gcpKmsOptions.Add("endpoint", gcpEndpoint);
+           }
+           kmsProviders.Add("gcp", gcpKmsOptions);
+
 ---
 title: Create a New Data Encryption Key
 ref: create-a-new-data-key-gcp
@@ -205,23 +220,10 @@ content: |
      .. tab::
         :tabid: nodejs
 
-        .. code-block:: javascript
+        .. note::
 
-           // TODO: check correctness
-           const key = await encryption.createDataKey('gcp', {
-              masterKey: {
-                provider: 'gcp',
-                projectId: '<GCP project identifier>',
-                location: '<GCP region>',
-                keyRing: '<GCP key ring name>',
-                keyName: '<GCP key name>',
-                keyVersion: '<GCP key version>',
-                endpoint: '<GCP KMS API endpoint>',
-              }
-           });
+           The Node.js driver does not currently support GCP KMS.
 
-           const base64DataKeyId = key.toString('base64');
-           console.log('DataKeyId [base64]: ', base64DataKeyId);
      .. tab::
         :tabid: python
 
@@ -244,6 +246,45 @@ content: |
 
            To use Google Cloud KMS, you must use `pymongocrypt <https://pypi.org/project/pymongocrypt/>`__
            version 1.1 or later in your application's environment.
+
+     .. tab::
+        :tabid: csharp
+
+        .. code-block:: csharp
+
+           // _connectionString is defined elsewhere as "mongodb://localhost:27017"
+
+           var keyVaultClient = new MongoClient(_connectionString);
+           var clientEncryptionOptions = new ClientEncryptionOptions(
+               keyVaultClient: keyVaultClient,
+               keyVaultNamespace: _keyVaultNamespace,
+               kmsProviders: kmsProviders);
+
+           var clientEncryption = new ClientEncryption(clientEncryptionOptions);
+
+
+           var gcpDataKeyProjectId = Environment.GetEnvironmentVariable("FLE_GCP_PROJ_ID");
+           var gcpDataKeyLocation = Environment.GetEnvironmentVariable("FLE_GCP_KEY_LOC"); // Optional. e.g. "global"
+           var gcpDataKeyKeyRing = Environment.GetEnvironmentVariable("FLE_GCP_KEY_RING");
+           var gcpDataKeyKeyName = Environment.GetEnvironmentVariable("FLE_GCP_KEY_NAME");
+           var gcpDataKeyKeyVersion = Environment.GetEnvironmentVariable("FLE_GCP_KEY_VERSION"); // Optional
+           var gcpDataKeyEndpoint = Environment.GetEnvironmentVariable("FLE_GCP_KMS_ENDPOINT"); // Optional, KMS URL, defaults to https://www.googleapis.com/auth/cloudkms
+
+           var dataKeyOptions = new DataKeyOptions(
+               masterKey: new BsonDocument
+               {
+                   { "projectId", gcpDataKeyProjectId },
+                   { "location", gcpDataKeyLocation } ,
+                   { "keyRing", gcpDataKeyKeyRing },
+                   { "keyName", gcpDataKeyKeyName },
+                   { "keyVersion", () => gcpDataKeyKeyVersion, gcpDataKeyKeyVersion != null },
+                   { "endpoint", () => gcpDataKeyEndpoint, gcpDataKeyEndpoint != null }
+               });
+
+           var dataKeyId = clientEncryption.CreateDataKey("gcp", dataKeyOptions, CancellationToken.None);
+           Console.WriteLine($"DataKeyId [UUID]: {dataKeyId}");
+           var dataKeyIdBase64 = Convert.ToBase64String(GuidConverter.ToBytes(dataKeyId, GuidRepresentation.Standard));
+           Console.WriteLine($"DataKeyId [base64]: {dataKeyIdBase64}");
 
 ---
 title: Update the Automatic Encryption JSON Schema


### PR DESCRIPTION
## Pull Request Info

This includes the config information for the dotnet driver to use gcp as a remote kms. It also cleans up the Node.js notes about not supporting GCP and Azure.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-13041

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/336656f/drivers/docsworker-xlarge/DOCSP-13041/security/client-side-field-level-encryption-local-key-to-kms#specify-your-google-cloud-kms-credentials
