### PR TITLE
DOCSP-13087: copy over CSFLE guides from security

### DIFF
--- a/source/use-cases/client-side-field-level-encryption-guide.txt
+++ b/source/use-cases/client-side-field-level-encryption-guide.txt
@@ -13,21 +13,31 @@ Client-Side Field Level Encryption Guide
 Who Is This Guide For?
 ----------------------
 
-This use case guide is an introduction to implementing automatic
-Client-Side Field Level Encryption using supported MongoDB drivers and is
-intended for **full-stack developers**. The guide presents the following
+This guide shows you how to implement automatic Client-Side Field Level
+Encryption (CSFLE) using supported MongoDB drivers and is intended for
+**full-stack developers**. The guide presents the following
 information in the context of a real-world scenario:
 
-- **How Client-Side Field Level Encryption works** (`Introduction`_)
-- **Reasons to choose this security feature** (`Comparison of Security
-  Features`_)
-- **How to implement Client-Side Field Level Encryption with the MongoDB
-  driver** (`Implementation`_)
+- :ref:`Introduction <csfle-guide-intro>`: How Client-Side Field Level
+  Encryption works
+- :ref:`Comparison of Security Features <csfle-feature-comparison>`: Reasons
+  to choose this security feature
+- :ref:`Impelementation <csfle-implementation>`: How to implement Client-Side
+  Field Level Encryption with the MongoDB driver
 
 .. note:: Download the Code
 
    For a runnable example of all the functionality demonstrated in this guide,
    see the :ref:`Download Example Project <download-example-project>` section.
+
+Once you complete the steps in this guide, you should have:
+
+- an understanding of how client-side field level encryption works and
+  in what situations it is practical
+- a working client application that demonstrates automatic CSFLE
+- resources on how to move the sample client application to production
+
+.. _csfle-guide-intro-old:
 
 Introduction
 ------------
@@ -106,6 +116,8 @@ of the following methods:
 What can MedcoMD do to balance the functionality and access restrictions
 of their Medical Care Management System?
 
+.. _csfle-feature-comparison-old:
+
 Comparison of Security Features
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -161,6 +173,8 @@ privacy of their own office.
 
 Equipped with CSFLE, MedcoMD can keep their sensitive data secure and
 compliant to data privacy regulations with MongoDB.
+
+.. _csfle-implementation-old:
 
 Implementation
 --------------
@@ -248,6 +262,24 @@ Additional Dependencies
              <https://pypi.org/project/pymongocrypt/>`_
            - Python wrapper for the ``libmongocrypt`` encryption library.
 
+   .. tab::
+      :tabid: csharp
+
+      .. list-table::
+         :header-rows: 1
+
+         * - Dependency Name
+           - Description
+
+         * - x64 Support
+           - x64 support is required for CSFLE
+
+
+         * - `mongocrypt.dll
+             <https://github.com/mongodb/libmongocrypt#installing-libmongocrypt-on-windows>`__
+           - A Windows build of `mongocrypt.dll`.
+
+
 .. _fle-create-a-master-key-old:
 
 A. Create a Master Key
@@ -277,7 +309,7 @@ encrypt and decrypt document fields, are stored in a key vault collection in
 the same MongoDB replica set as the encrypted data.
 
 
-.. warning:: Local Key Provider is not suitable for production
+.. warning:: The Local Key Provider is not suitable for production
 
    The Local Key Provider is an insecure method of storage and is therefore
    **not recommended** if you plan to use CSFLE in production. Instead,
@@ -351,6 +383,33 @@ to a file with the **fully runnable code below**:
         file_bytes = os.urandom(96)
         with open(path, "wb") as f:
           f.write(file_bytes)
+
+   .. tab::
+      :tabid: csharp
+
+      The following console program generates a 96-byte locally-managed master
+      key and saves it to a file called ``master-key.txt`` in the directory
+      from which the script is executed.
+
+      .. code-block:: csharp
+
+         using System;
+         using System.IO;
+
+         class Program
+         {
+             public void Main(string []args)
+             {
+                 using (var randomNumberGenerator = System.Security.Cryptography.RandomNumberGenerator.Create())
+                 {
+                     var bytes = new byte[96];
+                     randomNumberGenerator.GetBytes(bytes);
+                     var localMasterKeyBase64 = Convert.ToBase64String(bytes);
+                     Console.WriteLine(localMasterKeyBase64);
+                     File.WriteAllText(__localMasterKeyPath, localMasterKeyBase64);
+                 }
+             }
+         }
 
 B. Create a Data Encryption Key
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -599,6 +658,12 @@ full `JSON Schema for the Medical Care Management System
       View the **complete runnable** `helper code in Python
       <https://raw.githubusercontent.com/mongodb/docs-assets/DOCSP-json-schema-helper-and-json/json_schema_creator.py>`_.
 
+   .. tab::
+      :tabid: csharp
+
+      View the **complete runnable** `helper code in C#
+      <https://github.com/mongodb-university/csfle-guides/blob/master/dotnet/CSFLE/JsonSchemaCreator.cs>`_.
+
 D. Create the MongoDB Client
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -647,7 +712,6 @@ can provide configurable parameters including:
              .. example::
 
                 .. code-block:: java
-                   :emphasize-lines: 2,5,9
 
                    List<String> spawnArgs = new ArrayList<String>();
                    spawnArgs.add("--port=30000");
@@ -668,7 +732,6 @@ can provide configurable parameters including:
              .. example::
 
                 .. code-block:: java
-                   :emphasize-lines: 2-3,6,10
 
                    List<String> spawnArgs = new ArrayList<String>();
                    spawnArgs.add("--idleShutdownTimeoutSecs")
@@ -699,7 +762,6 @@ can provide configurable parameters including:
              .. example::
 
                 .. code-block:: javascript
-                   :emphasize-lines: 4-5
 
                    autoEncryption: {
                      ...
@@ -723,7 +785,6 @@ can provide configurable parameters including:
              .. example::
 
                 .. code-block:: javascript
-                   :emphasize-lines: 4
 
                    autoEncryption: {
                      ...
@@ -749,7 +810,6 @@ can provide configurable parameters including:
              .. example::
 
                 .. code-block:: python
-                   :emphasize-lines: 1
 
                    auto_encryption_opts = AutoEncryptionOpts(mongocryptd_spawn_args=['--port=30000'])
 
@@ -762,11 +822,57 @@ can provide configurable parameters including:
              .. example::
 
                 .. code-block:: python
-                   :emphasize-lines: 1
 
                    auto_encryption_opts = AutoEncryptionOpts(mongocryptd_spawn_args=['--idleShutdownTimeoutSecs=75'])
 
              | **Default**: ``60``
+
+   .. tab::
+      :tabid: csharp
+
+      .. list-table::
+         :header-rows: 1
+         :stub-columns: 1
+
+         * - Name
+           - Description
+
+
+         * - port
+           - | Listening port.
+             | Specify this value as follows:
+
+             .. example::
+
+                .. code-block:: csharp
+
+                   var extraOptions = new Dictionary<string, object>()
+                   {
+                       { "mongocryptdSpawnArgs", new [] { "--port=30000" } },
+                   };
+                   autoEncryptionOptions.With(extraOptions: extraOptions);
+
+             | **Default**: ``27020``
+
+         * - idleShutdownTimeoutSecs
+           - | Number of idle seconds in which the ``mongocryptd`` process should wait before exiting.
+             | Specify this value as follows:
+
+             .. example::
+
+                .. code-block:: csharp
+
+                   var extraOptions = new Dictionary<string, object>()
+                   {
+                       { "idleShutdownTimeoutSecs", 60 },
+                   };
+                   autoEncryptionOptions.With(extraOptions: extraOptions);
+
+
+                   auto_encryption_opts = AutoEncryptionOpts(mongocryptd_spawn_args=['--idleShutdownTimeoutSecs=75'])
+
+             | **Default**: ``60``
+
 
 .. note::
 
@@ -875,6 +981,56 @@ following **code snippet**:
            }
            collection.insert_one(doc)
 
+   .. tab::
+      :tabid: csharp
+
+      .. code-block:: csharp
+
+         var sampleSsnValue = 145014000;
+         var sampleNameValue = "John Doe";
+
+         BsonDocument sampleDocFields =
+             new BsonDocument
+             {
+                 { "name", sampleNameValue },
+                 { "ssn", sampleSsnValue },
+                 { "bloodType", "AB-" },
+                 {
+                     "medicalRecords",
+                     new BsonArray(new []
+                     {
+                         new BsonDocument("weight", 180),
+                         new BsonDocument("bloodPressure", "120/80")
+                     })
+                 },
+                 {
+                     "insurance",
+                     new BsonDocument
+                     {
+                         { "policyNumber", 123142 },
+                         { "provider", "MaestCare" }
+                     }
+                 }
+             };
+
+            // Construct an auto-encrypting client
+            var autoEncryptingClient = CreateAutoEncryptingClient(
+                kmsKeyLocation,
+                _keyVaultNamespace,
+                schema);
+            var collection = autoEncryptingClient
+                .GetDatabase(_medicalRecordsNamespace.DatabaseNamespace.DatabaseName)
+                .GetCollection<BsonDocument>(_medicalRecordsNamespace.CollectionName);
+
+
+            // Insert a document into the collection
+            collection.UpdateOne(ssnQuery, new BsonDocument("$set", __sampleDocFields), new UpdateOptions() { IsUpsert = true });
+            Console.WriteLine("Successfully upserted the sample document!");
+
+            Console.WriteLine($"Encrypted client query by the SSN (deterministically-encrypted) field:\n {result}\n");
+
+
+
 When a CSFLE-enabled client inserts a new patient record into the Medical Care
 Management System, it automatically encrypts the fields specified in the
 JSON Schema. This operation creates a document similar to the following:
@@ -956,7 +1112,6 @@ contains the last 4 digits of the ``ssn`` field. They could then query
 on this field as a proxy for the ``ssn``.
 
 .. code-block:: json
-   :emphasize-lines: 5
 
     {
         "_id": "5d6ecdce70401f03b27448fc",
@@ -1039,6 +1194,11 @@ To view and download a runnable example of CSFLE, select your driver below:
 
       **GitHub:** `PyMongo CSFLE runnable example
       <https://github.com/mongodb-university/csfle-guides/tree/master/python>`_
+   .. tab::
+      :tabid: csharp
+
+      **GitHub:** `C# CSFLE runnable example
+      <https://github.com/mongodb-university/csfle-guides/tree/master/dotnet>`_
 
 Move to Production
 ~~~~~~~~~~~~~~~~~~
@@ -1068,13 +1228,23 @@ check out the reference docs in the server manual:
    .. tab::
       :tabid: java-sync
 
-      For additional information on MongoDB CSFLE API, see the
-      :java-docs:`official Java driver documentation
-      <driver/tutorials/client-side-encryption/>`
+      For additional information on the MongoDB CSFLE API, see the
+      :java-docs:`official Java driver documentation <driver/tutorials/client-side-encryption/>`__.
+
    .. tab::
       :tabid: nodejs
 
-      For additional information on MongoDB CSFLE API, see the `official
-      Node.js driver documentation
-      <https://www.npmjs.com/package/mongodb-client-encryption>`_
+      For additional information on the MongoDB CSFLE API, see the
+      `official Node.js driver documentation <https://www.npmjs.com/package/mongodb-client-encryption>`__.
 
+   .. tab::
+      :tabid: python
+
+      For additional information on MongoDB CSFLE API, see the
+      `official PyMongo driver documentation <https://pymongo.readthedocs.io/en/stable/examples/encryption.html>`__.
+
+   .. tab::
+      :tabid: csharp
+
+      For additional information on MongoDB CSFLE API, see the
+      `official C# driver documentation <https://mongodb.github.io/mongo-csharp-driver/2.11/reference/driver/crud/client_side_encryption/>`__.

--- a/source/use-cases/client-side-field-level-encryption-guide.txt
+++ b/source/use-cases/client-side-field-level-encryption-guide.txt
@@ -2,8 +2,6 @@
 Client-Side Field Level Encryption Guide
 ========================================
 
-.. default-domain:: mongodb
-
 .. contents:: On this page
    :local:
    :backlinks: none
@@ -273,12 +271,6 @@ Additional Dependencies
 
          * - x64 Support
            - x64 support is required for CSFLE
-
-
-         * - `mongocrypt.dll
-             <https://github.com/mongodb/libmongocrypt#installing-libmongocrypt-on-windows>`__
-           - A Windows build of `mongocrypt.dll`.
-
 
 .. _fle-create-a-master-key-old:
 
@@ -868,8 +860,6 @@ can provide configurable parameters including:
                    };
                    autoEncryptionOptions.With(extraOptions: extraOptions);
 
-
-                   auto_encryption_opts = AutoEncryptionOpts(mongocryptd_spawn_args=['--idleShutdownTimeoutSecs=75'])
 
              | **Default**: ``60``
 

--- a/source/use-cases/client-side-field-level-encryption-local-key-to-kms.txt
+++ b/source/use-cases/client-side-field-level-encryption-local-key-to-kms.txt
@@ -15,259 +15,90 @@ Client-Side Field Level Encryption: Use a KMS to Store the Master Key
 Introduction
 ------------
 
-This guide is intended to help users migrate from using Client-Side Field
+This guide shows you how to migrate from using Client-Side Field
 Level Encryption (CSFLE) with a **locally-managed master key** to one that
-uses a remote **Key Management Service** such as
-`AWS KMS <https://aws.amazon.com/kms/>`_ to prepare their implementation
-for production. This guide assumes that you have already created
-a CSFLE-enabled client, appropriate access to the MongoDB replica set and
-AWS KMS.
+uses a remote **Key Management Service** (KMS) and is intended for
+**full-stack developers**.
 
-For a detailed walkthrough on developing and configuring a CSFLE client
-with an example use case, see our `CSFLE guide
-</security/client-side-field-level-encryption-guide>`_.
+Currently, MongoDB drivers support the following Key Management Providers:
 
-Reasons to Use a KMS
---------------------
+- `Amazon Web Services KMS <https://aws.amazon.com/kms/>`__
+- `Azure Key Vault <https://azure.microsoft.com/en-us/services/key-vault/>`__
+- `Google Cloud Platform Key Management <https://cloud.google.com/security-key-management>`__
+- Local KMS provider
 
-A remote KMS for master key management offers the following advantages over
-storing it on the local filesystem:
+Once you complete the steps in this guide, you should have:
 
-- Secure storage with access auditing
+- a master key hosted by one of the supported remote Key Management Services
+- a working client application that encrypts and decrypts the data
+  encryption key using the KMS master key
+
+Prerequisites
+-------------
+
+This guide requires that you completed the following:
+
+- created a CSFLE-enabled client using our `CSFLE guide </security/client-side-field-level-encryption-guide>`_
+- decrypted any data encrypted while using a local KMS master key
+
+Reasons to Use a Remote KMS
+---------------------------
+
+Choosing a remote KMS for master key management has the following advantages
+over using your local filesystem to host the master key:
+
+- Secure storage of the key with access auditing
 - Reduced risk of access permission issues
-- Availability and distribution to remote clients
-- Automated backup and recovery
+- Availability and distribution of the key to remote clients
+- Automated key backup and recovery
 - Centralized encryption key lifecycle management
 
 Additionally, MongoDB trasmits the data encryption keys to the KMS for
 encryption and decryption, ensuring the Customer Master Key (CMK) is never
 exposed to the client.
 
-Convert to a Remote Master Key
-------------------------------
+Set up a Remote Master Key
+--------------------------
 
 .. warning:: Decrypt all encrypted field data first
 
    Before you switch from a locally-managed master key to a remote KMS,
    you must decrypt all documents containing field-encrypted data if you
    want to keep it. Your existing data encryption keys can only be decrypted
-   with the original locally-managed master key and not the CMK that AWS KMS
-   generates.
+   with the original locally-managed master key and not the CMK that the
+   KMS generates.
 
    Failure to decrypt all data at this stage may cause permanent and
    unrecoverable data loss.
 
-This following steps explain the setup and updates necessary to move from
-a local key provider to AWS KMS.
+The following steps explain the setup and updates necessary to move from
+a local key provider to a KMS. Select the tab that corresponds to your
+provider:
 
-.. _create-an-aws-iam-user-old:
+.. tabs::
 
-Step 1: Create an AWS IAM User
-------------------------------
+   .. tab:: AWS KMS
+      :tabid: aws-kms
 
-Create a new programmatic IAM user in the AWS management console.
-CSFLE-enabled clients authenticate with AWS KMS using the IAM user to
-encrypt and decrypt the remote master key. The IAM user must be granted
-full ``List`` and ``Read`` permissions for the KMS service.
+      .. include:: /includes/steps/fle-convert-to-a-remote-master-key-aws.rst
 
-.. note:: Client IAM User Credentials
+   .. tab:: Azure Key Vault
+      :tabid: azure-kms
 
-   The CSFLE-enabled client uses the IAM User's :guilabel:`Access Key
-   ID` and :guilabel:`Secret Access Key` as configuration values. Take
-   note of these and reference them when we update the client.
+      .. include:: /includes/steps/fle-convert-to-a-remote-master-key-azure.rst
 
-.. _create-the-master-key-old:
+   .. tab:: Google Cloud Key Management
+      :tabid: google-kms
 
-Step 2: Create the Master Key
------------------------------
+      .. include:: /includes/steps/fle-convert-to-a-remote-master-key-gcp.rst
 
-The following diagram shows how the **master key** is created and stored
-when using a KMS provider:
-
-.. image:: /figures/CSFLE_Master_Key_KMS.png
-   :alt: Diagram that describes creating a master key when using a KMS provider
-
-In AWS management console, create a new symmetric master key in the KMS
-section. Choose a name and description that helps you identify it; these
-fields do not affect the functionality or configuration.
-
-In the :guilabel:`Usage Permissions` step of the key generation
-process, add the full KMS ``List`` and ``Read`` permissions to the IAM
-user you created in the previous step. This authorizes the user to encrypt
-and decrypt the new master key.
-
-.. important::
-
-   The new client IAM User *should not* have administrative permissions
-   for the master key.
-
-.. _specify-the-aws-kms-provider-credentials-old:
-
-Step 3: Specify the AWS KMS Provider Credentials
-------------------------------------------------
-
-Unlike the local key provider, the AWS KMS provider does not read
-the master key directly from the client application. Instead,
-it accepts the :guilabel:`Access Key ID` and :guilabel:`Secret Access
-Key` configurations that point to the master key. The IAM user must have
-the permissions set up in the previous step in order for the client to
-use the KMS to encrypt and decrypt data encryption keys.
-
-Update the KMS Provider configuration in your CSFLE-enabled client
-creation code:
-
-.. tabs-drivers::
-
-   .. tab::
-      :tabid: java-sync
-
-      .. code-block:: java
-
-         BsonString masterKeyRegion = new BsonString("<Master Key AWS Region>"); // e.g. "us-east-2"
-         BsonString awsAccessKeyId = new BsonString("<IAM User Access Key ID>");
-         BsonString awsSecretAccessKey = new BsonString("<IAM User Secret Access Key>");
-         Map<String, Map<String, Object>> kmsProviders = new HashMap<String, Map<String, Object>>();
-         Map<String, Object> providerDetails = new HashMap<String, Object>();
-
-         providerDetails.put("accessKeyId", awsAccessKeyId);
-         providerDetails.put("secretAccessKey", awsSecretAccessKey);
-         providerDetails.put("region", masterKeyRegion);
-
-         kmsProviders.put("aws", providerDetails);
-   .. tab::
-      :tabid: nodejs
-
-      .. code-block:: javascript
-
-         kmsProviders = {
-           aws: {
-             accessKeyId: '<IAM User Access Key ID>',
-             secretAccessKey: '<IAM User Secret Access Key>',
-           }
-         }
-   .. tab::
-      :tabid: python
-
-      .. code-block:: python
-
-         kms_providers = {
-             "aws": {
-                 "accessKeyId": "<IAM User Access Key ID>",
-                 "secretAccessKey": "<IAM User Secret Access Key>"
-             }
-         }
-
-.. _create-a-new-data-key-old:
-
-Step 4: Create a New Data Encryption Key
-----------------------------------------
-
-The following diagram shows how the **customer master key** is created and
-stored when using a KMS provider:
-
-.. image:: /figures/CSFLE_Data_Key_KMS.png
-   :alt: Diagram that describes creating a data encryption key when using a KMS provider
-
-You must generate a new **data encryption key** using the **master key**
-in the remote KMS. The original data encryption key was encrypted by
-your locally-managed master key.
-
-Specify the AWS region and `Amazon Resource Number
-<https://docs.aws.amazon.com/kms/latest/developerguide/viewing-keys.html#find-cmk-id-arn>`_
-(ARN) of the new CMK in the CSFLE-enabled client settings. Use the client
-to create a new data encryption key as follows:
-
-Once you have the required information, run the following code to
-generate the new data encryption key:
-
-.. tabs-drivers::
-
-   .. tab::
-      :tabid: java-sync
-
-      .. code-block:: Java
-
-         ClientEncryption clientEncryption = ClientEncryptions.create(ClientEncryptionSettings.builder()
-             .keyVaultMongoClientSettings(MongoClientSettings.builder()
-                 .applyConnectionString(new ConnectionString("mongodb://localhost:27017"))
-                 .build())
-             .keyVaultNamespace(keyVaultNamespace)
-             .kmsProviders(kmsProviders)
-             .build());
-
-         BsonString masterKeyRegion = new BsonString("<Master Key AWS Region>"); // e.g. "us-east-2"
-         BsonString masterKeyArn = new BsonString("<Master Key ARN>"); // e.g. "arn:aws:kms:us-east-2:111122223333:alias/test-key"
-         DataKeyOptions dataKeyOptions = new DataKeyOptions().masterKey(
-             new BsonDocument()
-                 .append("region", masterKeyRegion)
-                 .append("key", masterKeyArn));
-
-         BsonBinary dataKeyId = clientEncryption.createDataKey("aws", dataKeyOptions);
-         String base64DataKeyId = Base64.getEncoder().encodeToString(dataKeyId.getData());
-
-         System.out.println("DataKeyId [base64]: " + base64DataKeyId);
-   .. tab::
-      :tabid: nodejs
-
-      .. code-block:: javascript
-
-         const encryption = new ClientEncryption(client, {
-             keyVaultNamespace,
-             kmsProviders
-         });
-         const key = await encryption.createDataKey('aws', {
-            masterKey: {
-              key: '<Master Key ARN>', // e.g. 'arn:aws:kms:us-east-2:111122223333:alias/test-key'
-              region: '<Master Key AWS Region>', // e.g. 'us-east-1'
-            }
-         });
-
-         const base64DataKeyId = key.toString('base64');
-         console.log('DataKeyId [base64]: ', base64DataKeyId);
-   .. tab::
-      :tabid: python
-
-      .. code-block:: python
-
-         import pymongo
-         from pymongo import MongoClient
-         from pymongo.encryption_options import AutoEncryptionOpts
-         from bson.binary import STANDARD
-         from bson.codec_options import CodecOptions
-
-         connection_string = "mongodb://localhost:27017"
-         key_vault_namespace = "encryption.__keyVault"
-
-         fle_opts = AutoEncryptionOpts(
-            kms_providers, # pass in the kms_providers from the previous step
-            key_vault_namespace
-         )
-
-         client_encryption = pymongo.encryption.ClientEncryption(
-            {
-              "aws": {
-                "accessKeyId": "<IAM User Access Key ID>",
-                "secretAccessKey": "<IAM User Secret Access Key>"
-              }
-            },
-            key_vault_namespace,
-            client,
-            CodecOptions(uuid_representation=STANDARD)
-         )
-         data_key_id = client_encryption.create_data_key("aws")
-
-.. _update-the-json-schema-old:
-
-Step 5: Update the Automatic Encryption JSON Schema
----------------------------------------------------
-
-If you embedded the key id of your data encryption key in your
-automatic encryption rules, you will need to update the :ref:`JSON
-Schema <fle-define-a-json-schema>` with the new data encryption key id.
+Further Reading
+---------------
 
 For more information on client-side field level encryption in MongoDB,
-check out the reference docs in the server manual:
+check out the reference documentation in the MongoDB server manual:
 
 - :manual:`Client-Side Field Level Encryption </core/security-client-side-encryption>`
 - :manual:`Automatic Encryption JSON Schema Syntax </reference/security-client-side-automatic-json-schema>`
 - :manual:`Manage Client-Side Encryption Data Keys </tutorial/manage-client-side-encryption-data-keys>`
+


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-13087

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/feb8bd0/drivers/docsworker-xlarge/DOCSP-13087-copy-guides/use-cases/client-side-field-level-encryption-guide
https://docs-mongodbcom-staging.corp.mongodb.com/feb8bd0/drivers/docsworker-xlarge/DOCSP-13087-copy-guides/use-cases/client-side-field-level-encryption-local-key-to-kms
