### PR TITLE
DOCSP-13100: add link to pymongocrypt build instructions

### DIFF
--- a/source/includes/steps-fle-convert-to-a-remote-master-key-azure.yaml
+++ b/source/includes/steps-fle-convert-to-a-remote-master-key-azure.yaml
@@ -136,8 +136,9 @@ content: |
 
         .. note::
 
-           To use the Azure Key Vault, you must use `pymongocrypt <https://pypi.org/project/pymongocrypt/>`__
-           version 1.1 or later in your application's environment.
+           To use the Azure Key Vault, you must use ``pymongocrypt`` version
+           1.1 or later in your application's environment. Follow our guide
+           to `build libmongocrypt from source <https://github.com/mongodb/libmongocrypt/tree/master/bindings/python#installing-from-source>`__.
 
      .. tab::
         :tabid: csharp

--- a/source/includes/steps-fle-convert-to-a-remote-master-key-azure.yaml
+++ b/source/includes/steps-fle-convert-to-a-remote-master-key-azure.yaml
@@ -90,7 +90,6 @@ content: |
 
         .. code-block:: java
 
-           // TODO: verify correctness
            Map<String, Object> providerDetails = new HashMap<String, Object>();
 
            providerDetails.put("tenantId", new BsonString("<Azure account organization>"));
@@ -104,6 +103,12 @@ content: |
                // ...
                .kmsProviders(kmsProviders)
                .build();
+
+        .. note::
+
+           To use the Azure Key Vault, you must use `mongodb-crypt <https://mvnrepository.com/artifact/org.mongodb/mongodb-crypt>`__
+           version 1.1 or later in your application's environment.
+
 
      .. tab::
         :tabid: nodejs
@@ -128,6 +133,11 @@ content: |
                   "clientSecret": "<Azure client secret>"
               }
            }
+
+        .. note::
+
+           To use the Azure Key Vault, you must use `pymongocrypt <https://pypi.org/project/pymongocrypt/>`__
+           version 1.1 or later in your application's environment.
 
      .. tab::
         :tabid: csharp
@@ -155,8 +165,9 @@ content: |
 
         .. note::
 
-           To use the AWS Key Vault, you must use
+           To use the Azure KMS, you must use
            `libmongocrypt <https://github.com/mongodb/libmongocrypt#installing-libmongocrypt-on-windows>`__ version 1.1 or later in your application's environment.
+
 
 ---
 title: Create a New Data Encryption Key
@@ -215,11 +226,6 @@ content: |
 
            BsonBinary dataKeyId = clientEncryption.createDataKey("azure", dataKeyOptions);
 
-        .. note::
-
-           To use the Azure Key Vault, you must use `mongodb-crypt <https://mvnrepository.com/artifact/org.mongodb/mongodb-crypt>`__
-           version 1.1 or later in your application's environment.
-
      .. tab::
         :tabid: nodejs
 
@@ -240,11 +246,6 @@ content: |
              "keyVersion": "<Azure key version>",
              "keyVaultEndpoint": "<Azure key vault endpoint>"
            }
-
-        .. note::
-
-           To use the Azure Key Vault, you must use `pymongocrypt <https://pypi.org/project/pymongocrypt/>`__
-           version 1.1 or later in your application's environment.
 
      .. tab::
         :tabid: csharp
@@ -274,10 +275,6 @@ content: |
            var dataKeyIdBase64 = Convert.ToBase64String(GuidConverter.ToBytes(dataKeyId, GuidRepresentation.Standard));
            Console.WriteLine($"Azure DataKeyId [base64]: {dataKeyIdBase64}");
 
-        .. note::
-
-           To use the AWS Key Vault, you must use
-           `libmongocrypt <https://github.com/mongodb/libmongocrypt#installing-libmongocrypt-on-windows>`__ version 1.1 or later in your application's environment.
 
 ---
 title: Update the Automatic Encryption JSON Schema

--- a/source/includes/steps-fle-convert-to-a-remote-master-key-gcp.yaml
+++ b/source/includes/steps-fle-convert-to-a-remote-master-key-gcp.yaml
@@ -134,8 +134,9 @@ content: |
 
         .. note::
 
-           To use the GCP KMS, you must use `pymongocrypt <https://pypi.org/project/pymongocrypt/>`__
-           version 1.1 or later in your application's environment.
+           To use the GCP KMS, you must use ``pymongocrypt`` version
+           1.1 or later in your application's environment. Follow our guide
+           to `build libmongocrypt from source <https://github.com/mongodb/libmongocrypt/tree/master/bindings/python#installing-from-source>`__.
 
      .. tab::
         :tabid: csharp

--- a/source/includes/steps-fle-convert-to-a-remote-master-key-gcp.yaml
+++ b/source/includes/steps-fle-convert-to-a-remote-master-key-gcp.yaml
@@ -106,6 +106,12 @@ content: |
 
            kmsProviders.put("gcp", providerDetails);
 
+        .. note::
+
+           To use the GCP KMS, you must use
+           `mongodb-crypt <https://mvnrepository.com/artifact/org.mongodb/mongodb-crypt>`__
+           version 1.1 or later in your application's environment.
+
      .. tab::
         :tabid: nodejs
 
@@ -125,6 +131,11 @@ content: |
                    "endpoint": "<GCP authentication endpoint>",
                }
            }
+
+        .. note::
+
+           To use the GCP KMS, you must use `pymongocrypt <https://pypi.org/project/pymongocrypt/>`__
+           version 1.1 or later in your application's environment.
 
      .. tab::
         :tabid: csharp
@@ -146,6 +157,11 @@ content: |
                gcpKmsOptions.Add("endpoint", gcpEndpoint);
            }
            kmsProviders.Add("gcp", gcpKmsOptions);
+
+        .. note::
+
+           To use the GCP KMS, you must use
+           `libmongocrypt <https://github.com/mongodb/libmongocrypt#installing-libmongocrypt-on-windows>`__ version 1.1 or later in your application's environment.
 
 ---
 title: Create a New Data Encryption Key


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-13100

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/b05c620/drivers/docsworker-xlarge/DOCSP-13100-pymongocrypt-link/security/client-side-field-level-encryption-local-key-to-kms
