### PR TITLE
Swift 1.0 only supports 3.6+

### DIFF
--- a/source/includes/mongodb-compatibility-table-swift.rst
+++ b/source/includes/mongodb-compatibility-table-swift.rst
@@ -8,14 +8,12 @@
      - MongoDB 4.2
      - MongoDB 4.0
      - MongoDB 3.6
-     - MongoDB 3.4
 
    * - 1.0.0
      - |checkmark| (*)
      - |checkmark|
      - |checkmark|
      - |checkmark|
-     -
 
 The Swift driver is not compatible with MongoDB server versions older than 3.6.
 

--- a/source/includes/mongodb-compatibility-table-swift.rst
+++ b/source/includes/mongodb-compatibility-table-swift.rst
@@ -15,9 +15,9 @@
      - |checkmark|
      - |checkmark|
      - |checkmark|
-     - |checkmark|
+     -
 
-The Swift driver is not compatible with MongoDB server versions older than 3.4.
+The Swift driver is not compatible with MongoDB server versions older than 3.6.
 
 (*) Not all features in MongoDB 4.4 are available in this version of the
 driver including OCSP and MONGODB-AWS. These features will be included in


### PR DESCRIPTION
## Pull Request Info
This removes MongoDB 3.4 from the compatibility table for the Swift driver.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-13206

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/1ef7c40/drivers/docsworker-xlarge/DOCSP-13206/swift/#compatibility
