### PR TITLE
Update compatibility tables for PHP

### DIFF
--- a/source/includes/language-compatibility-table-php.rst
+++ b/source/includes/language-compatibility-table-php.rst
@@ -6,6 +6,7 @@
    :class: compatibility-large
 
    * - PHP Driver
+     - PHP 8.0
      - PHP 7.4
      - PHP 7.3
      - PHP 7.2
@@ -14,7 +15,18 @@
      - PHP 5.6
      - PHP 5.5
 
+   * - ext 1.9 + lib 1.8
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     -
+     -
+
    * - ext 1.8 + lib 1.7
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -24,6 +36,7 @@
      -
 
    * - ext 1.7 + lib 1.6
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -33,6 +46,7 @@
      -
 
    * - ext 1.6 + lib 1.5
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -42,6 +56,7 @@
      -
 
    * - ext 1.5 + lib 1.4
+     -
      -
      - |checkmark|
      - |checkmark|
@@ -53,6 +68,7 @@
    * - ext 1.4 + lib 1.3
      -
      -
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -60,6 +76,7 @@
      - |checkmark|
 
    * - ext 1.3 + lib 1.2
+     -
      -
      -
      - |checkmark|

--- a/source/includes/php-mongodb-compatibility-table.rst
+++ b/source/includes/php-mongodb-compatibility-table.rst
@@ -13,6 +13,16 @@
      - MongoDB 3.0
      - MongoDB 2.6
 
+   * - ext 1.9 + lib 1.8
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     -
+
    * - ext 1.8 + lib 1.7
      - |checkmark|
      - |checkmark|


### PR DESCRIPTION
This adds the upcoming PHP driver releases to the compatibility tables. Release candidates have been published, with final releases being rolled out next week.