### PR TITLE
go aws csfle

### DIFF
--- a/source/includes/steps-fle-convert-to-a-remote-master-key-aws.yaml
+++ b/source/includes/steps-fle-convert-to-a-remote-master-key-aws.yaml
@@ -134,6 +134,22 @@ content: |
            To use the AWS Key Vault, you must use
            `libmongocrypt <https://github.com/mongodb/libmongocrypt#installing-libmongocrypt-on-windows>`__ version 1.0 or later in your application's environment.
 
+     .. tab::
+        :tabid: go
+
+        .. code-block:: go
+
+           kmsProviders := map[string]map[string]interface{}{
+               "aws": {
+                   "accessKeyId":     os.Getenv("FLE_AWS_ACCESS_KEY"),
+                   "secretAccessKey": os.Getenv("FLE_AWS_SECRET_ACCESS_KEY"),
+               },
+           }
+
+        .. note::
+
+           In the companion project these values are retreived via struct tags.
+
 ---
 title: Create a New Data Encryption Key
 ref: create-a-new-data-key
@@ -292,6 +308,38 @@ content: |
 
            To use the AWS Key Vault, you must use
            `libmongocrypt <https://github.com/mongodb/libmongocrypt#installing-libmongocrypt-on-windows>`__ version 1.0 or later in your application's environment.
+
+     .. tab::
+        :tabid: go
+
+        .. code-block:: go
+
+           clientEncryptionOpts := options.ClientEncryption().SetKeyVaultNamespace(keyVaultNamespace).SetKmsProviders(kmsProviders)
+           keyVaultClient, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))
+           if err != nil {
+               log.Panicf("Client encryption connect error %v", err)
+           }
+           clientEnc, err := mongo.NewClientEncryption(keyVaultClient, clientEncryptionOpts)
+           if err != nil {
+               log.Panicf("NewClientEncryption error %v", err)
+           }
+           defer func() {
+               _ = clientEnc.Close(context.TODO())
+           }()
+           type awsKMSDataKeyOpts struct {
+               Region   string `bson:"region"`
+               KeyARN   string `bson:"key"`
+           }
+           dataKeyInfo := awsKMSDataKeyOpts {
+               Region: os.Getenv("FLE_AWS_REGION"),
+               KeyARN: os.Getenv("FLE_AWS_KEY_ARN"),
+           }
+           dataKeyOpts := options.DataKey().SetMasterKey(dataKeyInfo)
+           dataKeyID, err := clientEnc.CreateDataKey(context.TODO(), "aws", dataKeyOpts)
+           if err != nil {
+               log.Panicf("create data key error %v", err)
+           }
+           fmt.Println(base64.StdEncoding.EncodeToString(dataKeyID.Data))
 
 ---
 title: Update the Automatic Encryption JSON Schema

--- a/source/includes/steps-fle-convert-to-a-remote-master-key-aws.yaml
+++ b/source/includes/steps-fle-convert-to-a-remote-master-key-aws.yaml
@@ -137,18 +137,22 @@ content: |
      .. tab::
         :tabid: go
 
+        In ``kms/provider.go``, update the variable declarations or define the expected environmental variables in
+        ``AWSProvider()``.
+
         .. code-block:: go
 
-           kmsProviders := map[string]map[string]interface{}{
-               "aws": {
-                   "accessKeyId":     os.Getenv("FLE_AWS_ACCESS_KEY"),
-                   "secretAccessKey": os.Getenv("FLE_AWS_SECRET_ACCESS_KEY"),
-               },
+           awsAccessKeyID := GetCheckedEnv("FLE_AWS_ACCESS_KEY")
+           awsSecretAccessKey := GetCheckedEnv("FLE_AWS_SECRET_ACCESS_KEY")
+
+        The expected KMS provider map is created with struct tags.
+
+        .. code-block:: go
+
+           func (a *AWS) Credentials() map[string]map[string]interface{} {
+               return map[string]map[string]interface{}{"aws": structs.Map(a.credentials)}
            }
 
-        .. note::
-
-           In the companion project these values are retreived via struct tags.
 
 ---
 title: Create a New Data Encryption Key
@@ -312,34 +316,28 @@ content: |
      .. tab::
         :tabid: go
 
+        In ``kms/provider.go``, update the variable declarations or define the expected environmental variables
+        in ``AWSProvider()``.
+
         .. code-block:: go
 
-           clientEncryptionOpts := options.ClientEncryption().SetKeyVaultNamespace(keyVaultNamespace).SetKmsProviders(kmsProviders)
-           keyVaultClient, err := mongo.Connect(context.TODO(), options.Client().ApplyURI(uri))
-           if err != nil {
-               log.Panicf("Client encryption connect error %v", err)
+           awsKeyARN := GetCheckedEnv("FLE_AWS_KEY_ARN")
+           awsKeyRegion := GetCheckedEnv("FLE_AWS_KEY_REGION")
+
+        Struct tags are used to pass these values directly to the driver for use. In ``kms/provider.go``
+
+        .. code-block:: go
+
+           func (a *AWS) DataKeyOpts() interface{} {
+               return a.dataKeyOpts
            }
-           clientEnc, err := mongo.NewClientEncryption(keyVaultClient, clientEncryptionOpts)
-           if err != nil {
-               log.Panicf("NewClientEncryption error %v", err)
-           }
-           defer func() {
-               _ = clientEnc.Close(context.TODO())
-           }()
-           type awsKMSDataKeyOpts struct {
-               Region   string `bson:"region"`
-               KeyARN   string `bson:"key"`
-           }
-           dataKeyInfo := awsKMSDataKeyOpts {
-               Region: os.Getenv("FLE_AWS_REGION"),
-               KeyARN: os.Getenv("FLE_AWS_KEY_ARN"),
-           }
-           dataKeyOpts := options.DataKey().SetMasterKey(dataKeyInfo)
-           dataKeyID, err := clientEnc.CreateDataKey(context.TODO(), "aws", dataKeyOpts)
-           if err != nil {
-               log.Panicf("create data key error %v", err)
-           }
-           fmt.Println(base64.StdEncoding.EncodeToString(dataKeyID.Data))
+
+        In ``csfle/data_key.go``
+
+        .. code-block:: go
+
+           dataKeyOpts := options.DataKey().SetMasterKey(provider.DataKeyOpts())
+           dataKeyID, err := clientEnc.CreateDataKey(context.TODO(), provider.Name(), dataKeyOpts)
 
 ---
 title: Update the Automatic Encryption JSON Schema


### PR DESCRIPTION
## Pull Request Info
This adds go driver coverage for using AWS KMS.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-13212

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/97d7715/drivers/docsworker-xlarge/DOCSP-13212/security/client-side-field-level-encryption-local-key-to-kms#specify-the-aws-kms-provider-credentials