### PR TITLE
add gcp and azure kms

### DIFF
--- a/source/includes/steps-fle-convert-to-a-remote-master-key-aws.yaml
+++ b/source/includes/steps-fle-convert-to-a-remote-master-key-aws.yaml
@@ -101,6 +101,7 @@ content: |
                secretAccessKey: '<IAM User Secret Access Key>',
              }
            }
+
      .. tab::
         :tabid: python
 

--- a/source/includes/steps-fle-convert-to-a-remote-master-key-aws.yaml
+++ b/source/includes/steps-fle-convert-to-a-remote-master-key-aws.yaml
@@ -97,9 +97,9 @@ content: |
 
            kmsProviders = {
              aws: {
-               accessKeyId: '<IAM User Access Key ID>',
-               secretAccessKey: '<IAM User Secret Access Key>',
-             }
+               accessKeyId: "<IAM User Access Key ID>",
+               secretAccessKey: "<IAM User Secret Access Key>",
+             },
            }
 
      .. tab::
@@ -232,17 +232,17 @@ content: |
 
            const encryption = new ClientEncryption(client, {
                keyVaultNamespace,
-               kmsProviders
+               kmsProviders,
            });
-           const key = await encryption.createDataKey('aws', {
+           const key = await encryption.createDataKey("aws", {
               masterKey: {
-                key: '<Master Key ARN>', // e.g. 'arn:aws:kms:us-east-2:111122223333:alias/test-key'
-                region: '<Master Key AWS Region>' // e.g. 'us-east-2'
-              }
+                key: "<Master Key ARN>", // e.g. "arn:aws:kms:us-east-2:111122223333:alias/test-key"
+                region: "<Master Key AWS Region>", // e.g. "us-east-2"
+              },
            });
 
-           const base64DataKeyId = key.toString('base64');
-           console.log('DataKeyId [base64]: ', base64DataKeyId);
+           const base64DataKeyId = key.toString("base64");
+           console.log("DataKeyId [base64]: ", base64DataKeyId);
 
      .. tab::
         :tabid: python

--- a/source/includes/steps-fle-convert-to-a-remote-master-key-azure.yaml
+++ b/source/includes/steps-fle-convert-to-a-remote-master-key-azure.yaml
@@ -128,7 +128,7 @@ content: |
            .. note::
 
               To use the GCP KMS, you must use ``mongodb-client-encryption`` version
-              `1.1.1<https://www.npmjs.com/package/mongodb-client-encryption/v/1.1.1-beta.0>`__  or later.
+              `1.1.1 <https://www.npmjs.com/package/mongodb-client-encryption/v/1.1.1-beta.0>`__  or later.
 
         .. tab::
            :tabid: python

--- a/source/includes/steps-fle-convert-to-a-remote-master-key-azure.yaml
+++ b/source/includes/steps-fle-convert-to-a-remote-master-key-azure.yaml
@@ -127,7 +127,7 @@ content: |
 
            .. note::
 
-              To use the GCP KMS, you must use ``mongodb-client-encryption`` version
+              To use the Azure Key Vault, you must use ``mongodb-client-encryption`` version
               `1.1.1 <https://www.npmjs.com/package/mongodb-client-encryption/v/1.1.1-beta.0>`__  or later.
 
         .. tab::

--- a/source/includes/steps-fle-convert-to-a-remote-master-key-azure.yaml
+++ b/source/includes/steps-fle-convert-to-a-remote-master-key-azure.yaml
@@ -121,8 +121,8 @@ content: |
                 azure: {
                   tenantId: "<Azure account organization>",
                   clientId: "<Azure client ID>",
-                  clientSecret: "<Azure client secret>"
-                }
+                  clientSecret: "<Azure client secret>",
+                },
               }
 
            .. note::
@@ -271,17 +271,17 @@ content: |
 
               const encryption = new ClientEncryption(client, {
                   keyVaultNamespace,
-                  kmsProviders
+                  kmsProviders,
               });
-              const key = await encryption.createDataKey('azure', {
+              const key = await encryption.createDataKey("azure", {
                  masterKey: {
-                   keyName: '<Azure key name>',
-                   keyVaultEndpoint: '<Azure key vault endpoint>'
-                 }
+                   keyName: "<Azure key name>",
+                   keyVaultEndpoint: "<Azure key vault endpoint>",
+                 },
               });
 
-              const base64DataKeyId = key.toString('base64');
-              console.log('DataKeyId [base64]: ', base64DataKeyId);
+              const base64DataKeyId = key.toString("base64");
+              console.log("DataKeyId [base64]: ", base64DataKeyId);
 
 
         .. tab::

--- a/source/includes/steps-fle-convert-to-a-remote-master-key-azure.yaml
+++ b/source/includes/steps-fle-convert-to-a-remote-master-key-azure.yaml
@@ -273,7 +273,7 @@ content: |
                   keyVaultNamespace,
                   kmsProviders
               });
-              const key = await encryption.createDataKey('aws', {
+              const key = await encryption.createDataKey('azure', {
                  masterKey: {
                    keyName: '<Azure key name>',
                    keyVaultEndpoint: '<Azure key vault endpoint>'

--- a/source/includes/steps-fle-convert-to-a-remote-master-key-azure.yaml
+++ b/source/includes/steps-fle-convert-to-a-remote-master-key-azure.yaml
@@ -115,9 +115,20 @@ content: |
         .. tab::
            :tabid: nodejs
 
+           .. code-block:: javascript
+
+              kmsProviders = {
+                azure: {
+                  tenantId: "<Azure account organization>",
+                  clientId: "<Azure client ID>",
+                  clientSecret: "<Azure client secret>"
+                }
+              }
+
            .. note::
 
-              The Node.js driver does not currently support Azure KMS.
+              To use the GCP KMS, you must use ``mongodb-client-encryption`` version
+              `1.1.1<https://www.npmjs.com/package/mongodb-client-encryption/v/1.1.1-beta.0>`__  or later.
 
         .. tab::
            :tabid: python
@@ -256,9 +267,22 @@ content: |
         .. tab::
            :tabid: nodejs
 
-           .. note::
+           .. code-block:: javascript
 
-              The Node.js driver does not currently support Azure KMS.
+              const encryption = new ClientEncryption(client, {
+                  keyVaultNamespace,
+                  kmsProviders
+              });
+              const key = await encryption.createDataKey('aws', {
+                 masterKey: {
+                   keyName: '<Azure key name>',
+                   keyVaultEndpoint: '<Azure key vault endpoint>'
+                 }
+              });
+
+              const base64DataKeyId = key.toString('base64');
+              console.log('DataKeyId [base64]: ', base64DataKeyId);
+
 
         .. tab::
            :tabid: python

--- a/source/includes/steps-fle-convert-to-a-remote-master-key-gcp.yaml
+++ b/source/includes/steps-fle-convert-to-a-remote-master-key-gcp.yaml
@@ -129,7 +129,7 @@ content: |
           .. note::
 
              To use the GCP KMS, you must use ``mongodb-client-encryption`` version
-             `1.1.1<https://www.npmjs.com/package/mongodb-client-encryption/v/1.1.1-beta.0>`__  or later.
+             `1.1.1 <https://www.npmjs.com/package/mongodb-client-encryption/v/1.1.1-beta.0>`__  or later.
 
        .. tab::
           :tabid: python
@@ -295,11 +295,6 @@ content: |
 
               const base64DataKeyId = key.toString('base64');
               console.log('DataKeyId [base64]: ', base64DataKeyId);
-
-           .. note::
-
-              To use the GCP KMS, you must use ``mongodb-client-encryption`` version
-              `1.1.1<https://www.npmjs.com/package/mongodb-client-encryption/v/1.1.1-beta.0>`__  or later.
 
         .. tab::
            :tabid: python

--- a/source/includes/steps-fle-convert-to-a-remote-master-key-gcp.yaml
+++ b/source/includes/steps-fle-convert-to-a-remote-master-key-gcp.yaml
@@ -116,9 +116,20 @@ content: |
         .. tab::
           :tabid: nodejs
 
+          .. code-block:: javascript
+
+             kmsProviders = {
+               gcp: {
+                 emai": "<GCP service account email>",
+                 privateKey: "<GCP service account private key>",
+                 endpoint: "<GCP authentication endpoint>",
+               }
+             }
+
           .. note::
 
-             The Node.js driver does not currently support GCP KMS.
+             To use the GCP KMS, you must use ``mongodb-client-encryption`` version
+             `1.1.1<https://www.npmjs.com/package/mongodb-client-encryption/v/1.1.1-beta.0>`__  or later.
 
        .. tab::
           :tabid: python
@@ -264,9 +275,31 @@ content: |
         .. tab::
            :tabid: nodejs
 
+
+           .. code-block:: javascript
+
+              const encryption = new ClientEncryption(client, {
+                  keyVaultNamespace,
+                  kmsProviders
+              });
+              const key = await encryption.createDataKey('gcp', {
+                 masterKey: {
+                   projectId: "<GCP project identifier>",
+                   location: "<GCP region>",
+                   keyRing: "<GCP key ring name>",
+                   keyName: "<GCP key name>",
+                   keyVersion: "<GCP key version>",
+                   endpoint: "<GCP KMS API endpoint>",
+                 }
+              });
+
+              const base64DataKeyId = key.toString('base64');
+              console.log('DataKeyId [base64]: ', base64DataKeyId);
+
            .. note::
 
-              The Node.js driver does not currently support GCP KMS.
+              To use the GCP KMS, you must use ``mongodb-client-encryption`` version
+              `1.1.1<https://www.npmjs.com/package/mongodb-client-encryption/v/1.1.1-beta.0>`__  or later.
 
         .. tab::
            :tabid: python

--- a/source/includes/steps-fle-convert-to-a-remote-master-key-gcp.yaml
+++ b/source/includes/steps-fle-convert-to-a-remote-master-key-gcp.yaml
@@ -123,7 +123,7 @@ content: |
                  emai": "<GCP service account email>",
                  privateKey: "<GCP service account private key>",
                  endpoint: "<GCP authentication endpoint>",
-               }
+               },
              }
 
           .. note::
@@ -280,9 +280,9 @@ content: |
 
               const encryption = new ClientEncryption(client, {
                   keyVaultNamespace,
-                  kmsProviders
+                  kmsProviders,
               });
-              const key = await encryption.createDataKey('gcp', {
+              const key = await encryption.createDataKey("gcp", {
                  masterKey: {
                    projectId: "<GCP project identifier>",
                    location: "<GCP region>",
@@ -290,11 +290,11 @@ content: |
                    keyName: "<GCP key name>",
                    keyVersion: "<GCP key version>",
                    endpoint: "<GCP KMS API endpoint>",
-                 }
+                 },
               });
 
-              const base64DataKeyId = key.toString('base64');
-              console.log('DataKeyId [base64]: ', base64DataKeyId);
+              const base64DataKeyId = key.toString("base64");
+              console.log("DataKeyId [base64]: ", base64DataKeyId);
 
         .. tab::
            :tabid: python


### PR DESCRIPTION
## Pull Request Info

I combined both tickets into one. This includes the information required for both gcp and azure kms. It differs slightly from the companion project, but is close enough I don't think there will be any confusion.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-13040
https://jira.mongodb.org/browse/DOCSP-13036

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/1f73bc3/drivers/docsworker-xlarge/DOCSP-13036/security/client-side-field-level-encryption-local-key-to-kms#specify-the-azure-credentials
