### PR TITLE
DOCSP-13990: update java driver links for v4.2

### DIFF
--- a/source/includes/help-links-java.rst
+++ b/source/includes/help-links-java.rst
@@ -3,4 +3,4 @@ How to get help
 
 - Ask questions on our :community-forum:`MongoDB Community Forums <>`.
 - Visit our :technical-support:`Support Channels </>`.
-- See `Issues & Help <https://mongodb.github.io/mongo-java-driver/4.1/issues-help/>`__.
+- See :java-docs:`Issues & Help <issues-help/>`.

--- a/source/includes/language-compatibility-table-java-rs.rst
+++ b/source/includes/language-compatibility-table-java-rs.rst
@@ -9,6 +9,18 @@
      - Java 8
      - Java 11 [#backwards-compatible-rs]_
 
+   * - 4.2
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+
+   * - 4.1
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+
    * - 1.13
      - |checkmark|
      - |checkmark|

--- a/source/includes/language-compatibility-table-java.rst
+++ b/source/includes/language-compatibility-table-java.rst
@@ -10,6 +10,13 @@
      - Java 8
      - Java 11 [#backwards-compatible]_
 
+   * - Version 4.2
+     -
+     -
+     -
+     - |checkmark|
+     - |checkmark|
+
    * - Version 4.1
      -
      -

--- a/source/includes/language-compatibility-table-scala.rst
+++ b/source/includes/language-compatibility-table-scala.rst
@@ -9,6 +9,16 @@
      - Scala 2.12
      - Scala 2.11
 
+   * - 4.2
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+
+   * - 4.1
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+
    * - 2.9
      - |checkmark|
      - |checkmark|

--- a/source/includes/mongodb-compatibility-table-java-rs.rst
+++ b/source/includes/mongodb-compatibility-table-java-rs.rst
@@ -15,6 +15,16 @@
      - MongoDB 3.0
      - MongoDB 2.6
 
+   * - 4.2
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+
    * - 4.1
      - |checkmark|
      - |checkmark|

--- a/source/includes/mongodb-compatibility-table-java.rst
+++ b/source/includes/mongodb-compatibility-table-java.rst
@@ -15,6 +15,16 @@
      - MongoDB 3.0
      - MongoDB 2.6
 
+   * - Version 4.2
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+
    * - Version 4.1
      - |checkmark|
      - |checkmark|

--- a/source/includes/mongodb-compatibility-table-scala.rst
+++ b/source/includes/mongodb-compatibility-table-scala.rst
@@ -14,6 +14,16 @@
      - MongoDB 3.0
      - MongoDB 2.6
 
+   * - 4.2
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+
    * - 4.1
      - |checkmark|
      - |checkmark|

--- a/source/java.txt
+++ b/source/java.txt
@@ -23,7 +23,7 @@ The official MongoDB Java Driver providing both synchronous and asynchronous int
 
 - :java-docs:`Tutorials <driver/tutorials/>`
 
-- :java-docs:`API Documentation <apidocs/>`__
+- :java-docs:`API Documentation <apidocs/>`
 
 - :java-docs:`What's New <whats-new/>`
 

--- a/source/java.txt
+++ b/source/java.txt
@@ -19,13 +19,13 @@ Introduction
 
 The official MongoDB Java Driver providing both synchronous and asynchronous interaction with MongoDB.
 
-- `Reference Documentation <https://mongodb.github.io/mongo-java-driver/4.1/driver/>`__
+- :java-docs:`Reference Documentation <driver/>`
 
-- `Tutorials <https://mongodb.github.io/mongo-java-driver/4.1/driver/tutorials/>`__
+- :java-docs:`Tutorials <driver/tutorials/>`
 
-- `API Documentation <https://mongodb.github.io/mongo-java-driver/4.1/apidocs/>`__
+- :java-docs:`API Documentation <apidocs/>`__
 
-- `What's New <https://mongodb.github.io/mongo-java-driver/4.1/whats-new/>`__
+- :java-docs:`What's New <whats-new/>`
 
 - `Source Code <https://github.com/mongodb/mongo-java-driver/>`__
 
@@ -48,7 +48,7 @@ Installation
 ------------
 
 The recommended way to get started using one of the drivers in your project is with a dependency
-management system. See the `Installation Guide <https://mongodb.github.io/mongo-java-driver/4.1/driver/getting-started/installation/>`__
+management system. See the :java-docs:`Installation Guide <driver/getting-started/installation/>`
 for more information.
 
 
@@ -76,7 +76,7 @@ Connect to MongoDB Atlas
    MongoClient mongoClient = MongoClients.create(settings);
    MongoDatabase database = mongoClient.getDatabase("test");
 
-See `Connect to MongoDB <https://mongodb.github.io/mongo-java-driver/4.1/driver/tutorials/connect-to-mongodb/>`__
+See :java-docs:`Connect to MongoDB <driver/tutorials/connect-to-mongodb/>`
 for more ways to connect.
 
 

--- a/source/reactive-streams.txt
+++ b/source/reactive-streams.txt
@@ -22,12 +22,11 @@ recommended driver for working with reactive streams in the JVM ecosystem.
 
 - :java-docs:`Tutorials <driver-reactive/tutorials/>`
 
-- :java-docs:`API Documentation <apidocs/mongodb-driver-reactivestreams/index.html>`
+- :java-docs:`API Documentation <apidocs/mongodb-driver-reactivestreams/>`
 
-- :java-docs:`What's New whats-new/>`
+- :java-docs:`What's New <whats-new/>`
 
-- `Source Code
-  <https://github.com/mongodb/mongo-java-driver-reactivestreams/>`_
+- `Source Code <https://github.com/mongodb/mongo-java-driver-reactivestreams/>`__
 
 Installation
 ------------

--- a/source/reactive-streams.txt
+++ b/source/reactive-streams.txt
@@ -18,13 +18,13 @@ Introduction
 **Java Reactive Streams** is an official Java driver for MongoDB and is the
 recommended driver for working with reactive streams in the JVM ecosystem.
 
-- `Reference Documentation <https://mongodb.github.io/mongo-java-driver/4.1/driver-reactive/>`__
+- :java-docs:`Reference Documentation <driver-reactive/>`
 
-- `Tutorials <https://mongodb.github.io/mongo-java-driver/4.1/driver-reactive/tutorials/>`__
+- :java-docs:`Tutorials <driver-reactive/tutorials/>`
 
-- `API Documentation <https://mongodb.github.io/mongo-java-driver/4.1/apidocs/mongodb-driver-reactivestreams/index.html>`__
+- :java-docs:`API Documentation <apidocs/mongodb-driver-reactivestreams/index.html>`
 
-- `What's New <https://mongodb.github.io/mongo-java-driver/4.1/whats-new/>`__
+- :java-docs:`What's New whats-new/>`
 
 - `Source Code
   <https://github.com/mongodb/mongo-java-driver-reactivestreams/>`_
@@ -34,7 +34,7 @@ Installation
 
 The recommended way to get started using the driver in your project is with
 a dependency management system.
-See the `Installation Guide <https://mongodb.github.io/mongo-java-driver/4.1/driver-reactive/getting-started/installation/>`__
+See the :java-docs:`Installation Guide <driver-reactive/getting-started/installation/>`
 for more information.
 
 Connect to MongoDB Atlas
@@ -61,7 +61,7 @@ Connect to MongoDB Atlas
    MongoClient mongoClient = MongoClients.create(settings);
    MongoDatabase database = mongoClient.getDatabase("test");
 
-See `Connect to MongoDB <https://mongodb.github.io/mongo-java-driver/4.1/driver-reactive/tutorials/connect-to-mongodb/>`__
+See :java-docs:`Connect to MongoDB <driver-reactive/tutorials/connect-to-mongodb/>`
 for more ways to connect.
 
 Compatibility

--- a/source/scala.txt
+++ b/source/scala.txt
@@ -22,13 +22,13 @@ This is the officially supported Scala driver for MongoDB.
 It's a modern idiomatic Scala driver with asynchronous and non-blocking IO.
 
 
-- `Reference Documentation <http://mongodb.github.io/mongo-java-driver/4.1/driver-scala/>`__
+- :java-docs:`Reference Documentation <driver-scala/>`
   
-- `Tutorials <http://mongodb.github.io/mongo-java-driver/4.1/driver-scala/tutorials/>`__
+- :java-docs:`Tutorials <driver-scala/tutorials/>`
 
-- `API Documentation <http://mongodb.github.io/mongo-java-driver/4.1/apidocs/>`__
+- :java-docs:`API Documentation <apidocs/>`
 
-- `What's New <https://mongodb.github.io/mongo-java-driver/4.1/whats-new/>`__
+- :java-docs:`What's New <whats-new/>`
 
 - `Source Code <http://github.com/mongodb/mongo-scala-driver>`__
 
@@ -38,7 +38,7 @@ Installation
 
 The recommended way to get started using the driver in your project is
 with a dependency management system like ``sbt`` or ``maven``. See the
-`Installation Guide <http://mongodb.github.io/mongo-java-driver/4.1/driver-scala/getting-started/installation/>`__
+:java-docs:`Installation Guide <driver-scala/getting-started/installation/>`
 for more information.
 
 
@@ -59,7 +59,7 @@ Connect to MongoDB Atlas
    val db: MongoDatabase = client.getDatabase("test")
 
 
-See our guide on `Connecting <http://mongodb.github.io/mongo-java-driver/4.1/driver-scala/tutorials/connect-to-mongodb/>`__ 
+See our guide on :java-docs:`Connecting <driver-scala/tutorials/connect-to-mongodb/>`
 for more ways to connect.
 
 


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-13990

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/46c7f16/drivers/docsworker-xlarge/DOCSP-13990-update-java-42/java

https://docs-mongodbcom-staging.corp.mongodb.com/46c7f16/drivers/docsworker-xlarge/DOCSP-13990-update-java-42/reactive-streams

https://docs-mongodbcom-staging.corp.mongodb.com/46c7f16/drivers/docsworker-xlarge/DOCSP-13990-update-java-42/scala


