### PR TITLE
DOCS-14218: install latest pymongo version

### DIFF
--- a/source/pymongo.txt
+++ b/source/pymongo.txt
@@ -54,7 +54,7 @@ To get a specific version of pymongo:
 
 .. code-block:: sh
 
-   $ python -m pip install pymongo==3.5.1
+   $ python -m pip install pymongo==3.11
 
 To upgrade using pip:
 


### PR DESCRIPTION
## Pull Request Info

This changes the version under "install a specific version" to the latest version, should a user copy that instead of the default install.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCS-14218

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/fe9b466/drivers/docsworker-xlarge/DOCS-14218/pymongo/
