### PR TITLE
DOP-1883: clean up redirects for SEO

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -4,96 +4,101 @@ define: manual https://docs.mongodb.com/manual
 define: atlas https://docs.atlas.mongodb.com
 define: devhub https://developer.mongodb.com
 
-raw: drivers/platforms/amazon-ec2 -> ${atlas}/
-raw: drivers/platforms/red-hat-enterprise-linux -> ${manual}/tutorial/install-mongodb-enterprise-on-red-hat/
-raw: drivers/platforms/windows-azure -> ${atlas}/reference/microsoft-azure/#microsoft-azure
-raw: drivers/platforms/windows -> ${manual}/tutorial/install-mongodb-enterprise-on-windows/
-raw: drivers/tools/hadoop -> https://github.com/mongodb/mongo-hadoop
-raw: drivers/tools/munin -> https://github.com/comerford/mongo-munin
-raw: drivers/tutorial/authenticate-with-csharp-driver -> ${base}/csharp
-raw: drivers/tutorial/backup-and-restore-mongodb-on-amazon-ec2 -> ${atlas}/backup-restore-cluster/
-raw: drivers/tutorial/configure-red-hat-enterprise-linux-identity-management -> ${manual}/tutorial/install-mongodb-enterprise-on-red-hat/
-raw: drivers/tutorial/getting-started-with-hadoop -> https://github.com/mongodb/mongo-hadoop
-raw: drivers/tutorial/manage-red-hat-enterprise-linux-identity-management -> ${manual}/tutorial/install-mongodb-enterprise-on-red-hat/
-raw: drivers/use-cases/category-hierarchy -> ${devhub}
-raw: drivers/use-cases/hadoop -> https://github.com/mongodb/mongo-hadoop
-raw: drivers/use-cases/hierarchical-aggregation -> ${devhub}
-raw: drivers/use-cases/http-interfaces -> ${devhub}
-raw: drivers/use-cases/inventory-management -> ${devhub}
-raw: drivers/use-cases/metadata-and-asset-management -> ${devhub}
-raw: drivers/use-cases/product-catalog -> ${devhub}
-raw: drivers/use-cases/storing-comments -> ${devhub}
-raw: drivers/use-cases/storing-log-data -> ${devhub}
 
-raw: drivers/tutorial/install-mongodb-on-amazon-ec2 -> ${base}/platforms/amazon-ec2
-raw: drivers/tutorial/automate-deployment-with-cloudformation -> ${base}/platforms/amazon-ec2
-raw: drivers/tutorial/deploy-mongodb-from-aws-marketplace -> ${base}/platforms/amazon-ec2
-raw: drivers/tutorial/install-mongodb-on-windows-azure -> ${base}/platforms/windows-azure
-raw: drivers/tutorials -> ${base}/tutorial
-raw: drivers/javascript -> ${base}/drivers/node-js
+# FLE https://jira.mongodb.org/browse/DOP-1633
+raw: drivers/use-cases/client-side-field-level-encryption-guide -> ${base}/security/client-side-field-level-encryption-guide/
+raw: drivers/use-cases/client-side-field-level-encryption-local-key-to-kms -> ${base}/security/client-side-field-level-encryption-local-key-to-kms/
+raw: drivers/use-cases/sensitive-data-encryption ->  ${base}/security/client-side-field-level-encryption-guide/
+
+
+###
+### Redirects for Legacy Drivers Content
+###
+raw: drivers/tutorials -> ${base}/
+raw: drivers/perl-internals -> ${base}/drivers/community-supported-drivers/
+raw: drivers/downloads -> ${base}/drivers/
+raw: drivers/syntax-table -> ${base}/drivers/
+
+# cpp
 raw: drivers/tutorial/download-and-compile-cpp-driver -> https://github.com/mongodb/mongo-cxx-driver/wiki/Download%20and%20Compile
 raw: drivers/tutorial/getting-started-with-cpp-driver -> https://github.com/mongodb/mongo-cxx-driver/wiki/blob/legacy/README.md
 raw: drivers/cpp-bson-array-examples -> https://github.com/mongodb/mongo-cxx-driver/wiki/blob/legacy/src/mongo/client/examples/arrayExample.cpp
 raw: drivers/cpp-bson-helper-functions -> https://github.com/mongodb/mongo-cxx-driver/wiki/BSON%20Helper%20Functions
 raw: drivers/cpp-to-sql-to-mongo-shell -> https://github.com/mongodb/mongo-cxx-driver/wiki
-raw: drivers/tools/administration-interfaces -> ${base}/tools
-raw: drivers/tutorial/configure-worker-roles-in-azure -> ${base}/platforms/windows-azure
-raw: drivers/tutorial/deploy-mongodb-worker-roles-in-azure-version-1-6 -> ${base}/platforms/windows-azure
-raw: drivers/tutorial/deploy-mongodb-worker-roles-in-azure -> ${base}/platforms/windows-azure
-raw: drivers/tutorial/build-an-application-to-connect-to-mongodb-on-azure -> ${base}/platforms/windows-azure
-raw: drivers/tutorial/use-java-dbobject-to-perform-saves -> ${base}/drivers/java
+raw: drivers/tutorial/download-and-compile-cpp-driver-legacy -> https://github.com/mongodb/mongo-cxx-driver/wiki/Download-and-Compile-the-Legacy-Driver
+raw: drivers/tutorial/authenticate-with-cpp-driver -> https://mongodb.github.io/mongo-cxx-driver
+
+# csharp
+raw: drivers/tutorial/authenticate-with-csharp-driver -> ${base}/csharp/
+raw: drivers/csharp-community-projects -> ${base}/drivers/csharp/
+raw: drivers/tutorial/authenticate-with-csharp-driver -> http://mongodb.github.io/mongo-csharp-driver/2.2/reference/driver/authentication
+raw: drivers/tutorial/getting-started-with-csharp-driver -> http://mongodb.github.io/mongo-csharp-driver/2.2/getting_started
+raw: drivers/tutorial/serialize-documents-with-the-csharp-driver -> http://mongodb.github.io/mongo-csharp-driver/2.2/getting_started
+raw: drivers/tutorial/use-csharp-driver -> http://mongodb.github.io/mongo-csharp-driver/2.2/getting_started
+raw: drivers/tutorial/use-linq-queries-with-csharp-driver -> http://mongodb.github.io/mongo-csharp-driver/2.2/getting_started
+
+# java
 raw: drivers/java-concurrency -> http://mongodb.github.io/mongo-java-driver/3.0/driver/reference/crud
 raw: drivers/java-replica-set-semantics -> http://mongodb.github.io/mongo-java-driver/3.0/driver/reference/crud
 raw: drivers/java-types -> http://mongodb.github.io/mongo-java-driver/3.0/bson
 raw: drivers/tutorial/getting-started-with-3.0-java-driver -> http://mongodb.github.io/mongo-java-driver/3.0/driver/getting-started/quick-tour
 raw: drivers/tutorial/getting-started-with-java-driver -> http://mongodb.github.io/mongo-java-driver/2.13/getting-started/quick-tour
 raw: drivers/tutorial/use-aggregation-framework-with-java-driver -> http://mongodb.github.io/mongo-java-driver/3.0/driver/getting-started/quick-tour
-raw: drivers/csharp-community-projects -> ${base}/drivers/csharp
-raw: drivers/tutorial/authenticate-with-csharp-driver -> http://mongodb.github.io/mongo-csharp-driver/2.2/reference/driver/authentication
-raw: drivers/tutorial/getting-started-with-csharp-driver -> http://mongodb.github.io/mongo-csharp-driver/2.2/getting_started
-raw: drivers/tutorial/serialize-documents-with-the-csharp-driver -> http://mongodb.github.io/mongo-csharp-driver/2.2/getting_started
-raw: drivers/tutorial/use-csharp-driver -> http://mongodb.github.io/mongo-csharp-driver/2.2/getting_started
-raw: drivers/tutorial/use-linq-queries-with-csharp-driver -> http://mongodb.github.io/mongo-csharp-driver/2.2/getting_started
-raw: drivers/tutorial/getting-started-with-ruby-on-rails-3 -> ${base}/tutorial/ruby-bson-tutorial
-raw: drivers/tutorial/getting-started-with-ruby-on-rails -> ${base}/tutorial/ruby-bson-tutorial
+raw: drivers/tutorial/use-java-dbobject-to-perform-saves -> ${base}/drivers/java/
 raw: drivers/tutorial/authenticate-with-java-driver/ -> http://mongodb.github.io/mongo-java-driver/3.0/driver/reference/connecting/authenticating
-raw: drivers/tutorial/install-mongodb-on-linux-in-azure -> ${base}/platforms/windows-azure
-raw: drivers/tutorial/model-data-for-ruby-on-rails -> ${base}/drivers/ruby
-raw: drivers/tools/applications -> https://www.mongodb.com/community/deployments
-raw: drivers/tutorial/download-and-compile-cpp-driver-legacy -> https://github.com/mongodb/mongo-cxx-driver/wiki/Download-and-Compile-the-Legacy-Driver
-raw: drivers/ruby -> https://docs.mongodb.com/ruby-driver/current
-raw: drivers/ruby-resources -> https://docs.mongodb.com/ruby-driver/current/reference/additional-resources
-raw: drivers/tutorial/ruby-driver-tutorial -> https://docs.mongodb.com/ruby-driver/v2.2
-raw: drivers/tutorial/ruby-driver-tutorial-2-0 -> https://docs.mongodb.com/ruby-driver/v2.0
-raw: drivers/tutorial/ruby-bson-tutorial -> https://docs.mongodb.com/ruby-driver/current/tutorials/bson-v4
-raw: drivers/tutorial/ruby-bson-tutorial-4-0 -> https://docs.mongodb.com/ruby-driver/current/tutorials/bson-v4
-raw: drivers/tutorial/ruby-mongoid-tutorial -> https://docs.mongodb.com/mongoid/current/
-raw: drivers/tutorial/mongoid-callbacks -> https://docs.mongodb.com/mongoid/current/tutorials/mongoid-callbacks/
-raw: drivers/tutorial/mongoid-documents -> https://docs.mongodb.com/mongoid/current/tutorials/mongoid-documents
-raw: drivers/tutorial/mongoid-indexes -> https://docs.mongodb.com/mongoid/current/tutorials/mongoid-indexes
-raw: drivers/tutorial/mongoid-installation -> https://docs.mongodb.com/mongoid/current/tutorials/mongoid-installation
-raw: drivers/tutorial/mongoid-nested-attributes -> https://docs.mongodb.com/mongoid/current/tutorials/mongoid-nested-attributes
-raw: drivers/tutorial/mongoid-persistence -> https://docs.mongodb.com/mongoid/current/tutorials/mongoid-persistence
-raw: drivers/tutorial/mongoid-queries -> https://docs.mongodb.com/mongoid/current/tutorials/mongoid-queries
-raw: drivers/tutorial/mongoid-rails -> https://docs.mongodb.com/mongoid/current/tutorials/mongoid-rails
-raw: drivers/tutorial/mongoid-relations -> https://docs.mongodb.com/mongoid/current/tutorials/mongoid-relations
-raw: drivers/tutorial/mongoid-upgrade -> https://docs.mongodb.com/mongoid/current/tutorials/mongoid-upgrade
-raw: drivers/tutorial/mongoid-validation -> https://docs.mongodb.com/mongoid/current/tutorials/mongoid-validation
-raw: drivers/downloads -> ${base}/drivers
-raw: drivers/tutorial/write-a-tumblelog-application-with-flask-mongoengine -> https://pymodm.readthedocs.io/en/latest/getting-started.html
-raw: drivers/use-cases/pre-aggregated-reports -> ${base}/use-cases/pre-aggregated-reports-mmapv1
-raw: drivers/tutorial/authenticate-with-cpp-driver -> https://mongodb.github.io/mongo-cxx-driver
-raw: drivers/perl-internals -> ${base}/drivers/perl
-raw: drivers/platforms/digitalocean -> https://docs.atlas.mongodb.com
-raw: drivers/platforms/modulus -> https://docs.atlas.mongodb.com
-raw: drivers/platforms/rackspace-cloud -> https://docs.atlas.mongodb.com
-raw: drivers/platforms/red-hat-openshift -> https://docs.mongodb.com/kubernetes-operator/stable/
-raw: drivers/platforms/dotcloud -> https://docs.atlas.mongodb.com
-raw: drivers/platforms/vmware-cloud-foundry -> https://pivotal.io/platform/services-marketplace/data-management/mongodb
-raw: drivers/use-cases/pre-aggregated-reports-mmapv1 -> https://docs.mongodb.com/manual/changeStreams
-raw: drivers/tools/wireshark -> https://wiki.wireshark.org/Mongo
-raw: drivers/syntax-table -> ${base}/drivers
-raw: drivers/use-cases/sensitive-data-encryption ->  ${base}/use-cases/client-side-field-level-encryption-guide
+
+# nodejs
+raw: drivers/javascript -> ${base}/drivers/node-js/
+
+# ruby and mongoid
+raw: drivers/tutorial/getting-started-with-ruby-on-rails-3 -> ${base}/tutorial/ruby-bson-tutorial/
+raw: drivers/tutorial/getting-started-with-ruby-on-rails -> ${base}/tutorial/ruby-bson-tutorial/
+raw: drivers/tutorial/model-data-for-ruby-on-rails -> ${base}/drivers/ruby/
+raw: drivers/ruby -> https://docs.mongodb.com/ruby-driver/current/
+raw: drivers/ruby-resources -> https://docs.mongodb.com/ruby-driver/current/reference/additional-resources/
+raw: drivers/tutorial/ruby-driver-tutorial -> https://docs.mongodb.com/ruby-driver/v2.2/
+raw: drivers/tutorial/ruby-driver-tutorial-2-0 -> https://docs.mongodb.com/ruby-driver/v2.0/
+raw: drivers/tutorial/ruby-bson-tutorial -> https://docs.mongodb.com/ruby-driver/current/tutorials/bson-v4/
+raw: drivers/tutorial/ruby-bson-tutorial-4-0 -> https://docs.mongodb.com/ruby-driver/current/tutorials/bson-v4/
+raw: drivers/tutorial/ruby-mongoid-tutorial -> https://docs.mongodb.com/mongoid/current//
+raw: drivers/tutorial/mongoid-callbacks -> https://docs.mongodb.com/mongoid/current/tutorials/mongoid-callbacks//
+raw: drivers/tutorial/mongoid-documents -> https://docs.mongodb.com/mongoid/current/tutorials/mongoid-documents/
+raw: drivers/tutorial/mongoid-indexes -> https://docs.mongodb.com/mongoid/current/tutorials/mongoid-indexes/
+raw: drivers/tutorial/mongoid-installation -> https://docs.mongodb.com/mongoid/current/tutorials/mongoid-installation/
+raw: drivers/tutorial/mongoid-nested-attributes -> https://docs.mongodb.com/mongoid/current/tutorials/mongoid-nested-attributes/
+raw: drivers/tutorial/mongoid-persistence -> https://docs.mongodb.com/mongoid/current/tutorials/mongoid-persistence/
+raw: drivers/tutorial/mongoid-queries -> https://docs.mongodb.com/mongoid/current/tutorials/mongoid-queries/
+raw: drivers/tutorial/mongoid-rails -> https://docs.mongodb.com/mongoid/current/tutorials/mongoid-rails/
+raw: drivers/tutorial/mongoid-relations -> https://docs.mongodb.com/mongoid/current/tutorials/mongoid-relations/
+raw: drivers/tutorial/mongoid-upgrade -> https://docs.mongodb.com/mongoid/current/tutorials/mongoid-upgrade/
+raw: drivers/tutorial/mongoid-validation -> https://docs.mongodb.com/mongoid/current/tutorials/mongoid-validation/
+
+###
+### Redirects for Legacy Ecosystem Content
+###
+# Amazon ec2 -> Atlas
+raw: drivers/platforms/amazon-ec2 -> ${atlas}/
+raw: drivers/tutorial/install-mongodb-on-amazon-ec2 -> ${atlas}/
+raw: drivers/tutorial/automate-deployment-with-cloudformation -> ${atlas}/
+raw: drivers/tutorial/deploy-mongodb-from-aws-marketplace -> ${atlas}/
+raw: drivers/tutorial/backup-and-restore-mongodb-on-amazon-ec2 -> ${atlas}/backup-restore-cluster/
+
+# Azure -> Atlas / Manual
+raw: drivers/platforms/windows-azure -> ${atlas}/reference/microsoft-azure/
+raw: drivers/platforms/windows -> ${manual}/tutorial/install-mongodb-enterprise-on-windows/
+raw: drivers/tutorial/install-mongodb-on-windows-azure -> ${atlas}/reference/microsoft-azure/
+raw: drivers/tutorial/configure-worker-roles-in-azure -> ${atlas}/reference/microsoft-azure/
+raw: drivers/tutorial/deploy-mongodb-worker-roles-in-azure-version-1-6 -> ${atlas}/reference/microsoft-azure/
+raw: drivers/tutorial/deploy-mongodb-worker-roles-in-azure -> ${atlas}/reference/microsoft-azure/
+raw: drivers/tutorial/build-an-application-to-connect-to-mongodb-on-azure -> ${atlas}/reference/microsoft-azure/
+raw: drivers/tutorial/install-mongodb-on-linux-in-azure -> ${base}/platforms/windows-azure/
+
+# Hadoop
+raw: drivers/tools/hadoop -> https://github.com/mongodb/mongo-hadoop
+raw: drivers/use-cases/hadoop -> https://github.com/mongodb/mongo-hadoop
+raw: drivers/tutorial/getting-started-with-hadoop -> https://github.com/mongodb/mongo-hadoop/
+
+# Kafka -> Kafka Connector site
 raw: drivers/connectors/kafka -> ${kafka}
 raw: drivers/connectors/kafka-connect-migration -> ${kafka}/kafka-connect-migration
 raw: drivers/connectors/kafka-docker-example -> ${kafka}/kafka-docker-example
@@ -104,8 +109,37 @@ raw: drivers/connectors/kafka-sink-postprocessors -> ${kafka}/kafka-sink-postpro
 raw: drivers/connectors/kafka-sink-properties -> ${kafka}/kafka-sink-properties
 raw: drivers/connectors/kafka-sink -> ${kafka}/kafka-sink
 raw: drivers/connectors/kafka-source -> ${kafka}/kafka-source
-raw: drivers/tools/http-interfaces -> ${base}/use-cases/http-interfaces
 
-# https://jira.mongodb.org/browse/DOP-1633
-raw: drivers/use-cases/client-side-field-level-encryption-guide -> ${base}/security/client-side-field-level-encryption-guide/
-raw: drivers/use-cases/client-side-field-level-encryption-local-key-to-kms -> ${base}/security/client-side-field-level-encryption-local-key-to-kms/
+# Platforms
+raw: drivers/platforms/digitalocean -> https://docs.atlas.mongodb.com
+raw: drivers/platforms/modulus -> https://docs.atlas.mongodb.com
+raw: drivers/platforms/rackspace-cloud -> https://docs.atlas.mongodb.com
+raw: drivers/platforms/red-hat-openshift -> https://docs.mongodb.com/kubernetes-operator/stable/
+raw: drivers/platforms/dotcloud -> https://docs.atlas.mongodb.com
+raw: drivers/platforms/vmware-cloud-foundry -> https://pivotal.io/platform/services-marketplace/data-management/mongodb
+
+# RHEL -> Manual
+raw: drivers/platforms/red-hat-enterprise-linux -> ${manual}/tutorial/install-mongodb-enterprise-on-red-hat/
+raw: drivers/tutorial/configure-red-hat-enterprise-linux-identity-management -> ${manual}/tutorial/install-mongodb-enterprise-on-red-hat/
+raw: drivers/tutorial/manage-red-hat-enterprise-linux-identity-management -> ${manual}/tutorial/install-mongodb-enterprise-on-red-hat/
+
+# Tools
+raw: drivers/tools/munin -> https://github.com/comerford/mongo-munin
+raw: drivers/tools/administration-interfaces -> https://docs.mongodb.com/tools/
+raw: drivers/tools/wireshark -> https://wiki.wireshark.org/Mongo
+raw: drivers/tools/applications -> https://www.mongodb.com/community
+
+# Use Cases -> Devhub
+raw: drivers/use-cases/category-hierarchy -> ${devhub}/
+raw: drivers/use-cases/hierarchical-aggregation -> ${devhub}/
+raw: drivers/use-cases/http-interfaces -> ${devhub}/
+raw: drivers/tools/http-interfaces -> ${devhub}/
+raw: drivers/use-cases/inventory-management -> ${devhub}/
+raw: drivers/use-cases/metadata-and-asset-management -> ${devhub}/
+raw: drivers/use-cases/product-catalog -> ${devhub}/
+raw: drivers/use-cases/storing-comments -> ${devhub}/
+raw: drivers/use-cases/storing-log-data -> ${devhub}/
+raw: drivers/use-cases/pre-aggregated-reports-mmapv1 -> ${manual}/changeStreams/
+raw: drivers/use-cases/pre-aggregated-reports -> ${manual}/changeStreams/
+raw: drivers/tutorial/write-a-tumblelog-application-with-flask-mongoengine -> https://pymodm.readthedocs.io/en/latest/getting-started.html
+

--- a/config/redirects
+++ b/config/redirects
@@ -15,9 +15,9 @@ raw: drivers/use-cases/sensitive-data-encryption ->  ${base}/security/client-sid
 ### Redirects for Legacy Drivers Content
 ###
 raw: drivers/tutorials -> ${base}/
-raw: drivers/perl-internals -> ${base}/drivers/community-supported-drivers/
-raw: drivers/downloads -> ${base}/drivers/
-raw: drivers/syntax-table -> ${base}/drivers/
+raw: drivers/perl-internals -> ${base}/community-supported-drivers/
+raw: drivers/downloads -> ${base}/
+raw: drivers/syntax-table -> ${base}/
 
 # cpp
 raw: drivers/tutorial/download-and-compile-cpp-driver -> https://github.com/mongodb/mongo-cxx-driver/wiki/Download%20and%20Compile
@@ -26,11 +26,11 @@ raw: drivers/cpp-bson-array-examples -> https://github.com/mongodb/mongo-cxx-dri
 raw: drivers/cpp-bson-helper-functions -> https://github.com/mongodb/mongo-cxx-driver/wiki/BSON%20Helper%20Functions
 raw: drivers/cpp-to-sql-to-mongo-shell -> https://github.com/mongodb/mongo-cxx-driver/wiki
 raw: drivers/tutorial/download-and-compile-cpp-driver-legacy -> https://github.com/mongodb/mongo-cxx-driver/wiki/Download-and-Compile-the-Legacy-Driver
-raw: drivers/tutorial/authenticate-with-cpp-driver -> https://mongodb.github.io/mongo-cxx-driver
+raw: drivers/tutorial/authenticate-with-cpp-driver -> http://mongocxx.org/
 
 # csharp
 raw: drivers/tutorial/authenticate-with-csharp-driver -> ${base}/csharp/
-raw: drivers/csharp-community-projects -> ${base}/drivers/csharp/
+raw: drivers/csharp-community-projects -> ${base}/csharp/
 raw: drivers/tutorial/authenticate-with-csharp-driver -> http://mongodb.github.io/mongo-csharp-driver/2.2/reference/driver/authentication
 raw: drivers/tutorial/getting-started-with-csharp-driver -> http://mongodb.github.io/mongo-csharp-driver/2.2/getting_started
 raw: drivers/tutorial/serialize-documents-with-the-csharp-driver -> http://mongodb.github.io/mongo-csharp-driver/2.2/getting_started
@@ -44,16 +44,16 @@ raw: drivers/java-types -> http://mongodb.github.io/mongo-java-driver/3.0/bson
 raw: drivers/tutorial/getting-started-with-3.0-java-driver -> http://mongodb.github.io/mongo-java-driver/3.0/driver/getting-started/quick-tour
 raw: drivers/tutorial/getting-started-with-java-driver -> http://mongodb.github.io/mongo-java-driver/2.13/getting-started/quick-tour
 raw: drivers/tutorial/use-aggregation-framework-with-java-driver -> http://mongodb.github.io/mongo-java-driver/3.0/driver/getting-started/quick-tour
-raw: drivers/tutorial/use-java-dbobject-to-perform-saves -> ${base}/drivers/java/
+raw: drivers/tutorial/use-java-dbobject-to-perform-saves -> ${base}/java/
 raw: drivers/tutorial/authenticate-with-java-driver/ -> http://mongodb.github.io/mongo-java-driver/3.0/driver/reference/connecting/authenticating
 
 # nodejs
-raw: drivers/javascript -> ${base}/drivers/node-js/
+raw: drivers/javascript -> ${base}/node/
 
 # ruby and mongoid
-raw: drivers/tutorial/getting-started-with-ruby-on-rails-3 -> ${base}/tutorial/ruby-bson-tutorial/
-raw: drivers/tutorial/getting-started-with-ruby-on-rails -> ${base}/tutorial/ruby-bson-tutorial/
-raw: drivers/tutorial/model-data-for-ruby-on-rails -> ${base}/drivers/ruby/
+raw: drivers/tutorial/getting-started-with-ruby-on-rails-3 -> https://docs.mongodb.com/ruby-driver/current/tutorials/bson-v4/
+raw: drivers/tutorial/getting-started-with-ruby-on-rails ->https://docs.mongodb.com/ruby-driver/current/tutorials/bson-v4/
+raw: drivers/tutorial/model-data-for-ruby-on-rails -> ${base}/ruby/
 raw: drivers/ruby -> https://docs.mongodb.com/ruby-driver/current/
 raw: drivers/ruby-resources -> https://docs.mongodb.com/ruby-driver/current/reference/additional-resources/
 raw: drivers/tutorial/ruby-driver-tutorial -> https://docs.mongodb.com/ruby-driver/v2.2/
@@ -142,4 +142,3 @@ raw: drivers/use-cases/storing-log-data -> ${devhub}/
 raw: drivers/use-cases/pre-aggregated-reports-mmapv1 -> ${manual}/changeStreams/
 raw: drivers/use-cases/pre-aggregated-reports -> ${manual}/changeStreams/
 raw: drivers/tutorial/write-a-tumblelog-application-with-flask-mongoengine -> https://pymodm.readthedocs.io/en/latest/getting-started.html
-

--- a/config/redirects
+++ b/config/redirects
@@ -99,23 +99,23 @@ raw: drivers/use-cases/hadoop -> https://github.com/mongodb/mongo-hadoop
 raw: drivers/tutorial/getting-started-with-hadoop -> https://github.com/mongodb/mongo-hadoop/
 
 # Kafka -> Kafka Connector site
-raw: drivers/connectors/kafka -> ${kafka}
-raw: drivers/connectors/kafka-connect-migration -> ${kafka}/kafka-connect-migration
-raw: drivers/connectors/kafka-docker-example -> ${kafka}/kafka-docker-example
-raw: drivers/connectors/kafka-installation -> ${kafka}/kafka-installation
-raw: drivers/connectors/kafka-sink-cdc -> ${kafka}/kafka-sink-cdc
-raw: drivers/connectors/kafka-sink-data-formats -> ${kafka}/kafka-sink-data-formats
-raw: drivers/connectors/kafka-sink-postprocessors -> ${kafka}/kafka-sink-postprocessors
-raw: drivers/connectors/kafka-sink-properties -> ${kafka}/kafka-sink-properties
-raw: drivers/connectors/kafka-sink -> ${kafka}/kafka-sink
-raw: drivers/connectors/kafka-source -> ${kafka}/kafka-source
+raw: drivers/connectors/kafka -> ${kafka}/
+raw: drivers/connectors/kafka-connect-migration -> ${kafka}/kafka-connect-migration/
+raw: drivers/connectors/kafka-docker-example -> ${kafka}/kafka-docker-example/
+raw: drivers/connectors/kafka-installation -> ${kafka}/kafka-installation/
+raw: drivers/connectors/kafka-sink-cdc -> ${kafka}/kafka-sink-cdc/
+raw: drivers/connectors/kafka-sink-data-formats -> ${kafka}/kafka-sink-data-formats/
+raw: drivers/connectors/kafka-sink-postprocessors -> ${kafka}/kafka-sink-postprocessors/
+raw: drivers/connectors/kafka-sink-properties -> ${kafka}/kafka-sink-properties/
+raw: drivers/connectors/kafka-sink -> ${kafka}/kafka-sink/
+raw: drivers/connectors/kafka-source -> ${kafka}/kafka-source/
 
 # Platforms
-raw: drivers/platforms/digitalocean -> https://docs.atlas.mongodb.com
-raw: drivers/platforms/modulus -> https://docs.atlas.mongodb.com
-raw: drivers/platforms/rackspace-cloud -> https://docs.atlas.mongodb.com
+raw: drivers/platforms/digitalocean -> https://docs.atlas.mongodb.com/
+raw: drivers/platforms/modulus -> https://docs.atlas.mongodb.com/
+raw: drivers/platforms/rackspace-cloud -> https://docs.atlas.mongodb.com/
 raw: drivers/platforms/red-hat-openshift -> https://docs.mongodb.com/kubernetes-operator/stable/
-raw: drivers/platforms/dotcloud -> https://docs.atlas.mongodb.com
+raw: drivers/platforms/dotcloud -> https://docs.atlas.mongodb.com/
 raw: drivers/platforms/vmware-cloud-foundry -> https://pivotal.io/platform/services-marketplace/data-management/mongodb
 
 # RHEL -> Manual


### PR DESCRIPTION
## Pull Request Info

*This addresses redirection chains in the docs-ecosystem repo as part of the SEO project*

- Organizes redirects and removes redirect chains (organization was required to *find* the redirection chains)
- Ensures all redirects to docs.mongodb.com/ pages point at the canonical (with `/`) URL to avoid extra redirect steps


### Issue JIRA link:
https://jira.mongodb.org/browse/DOP-1883

Generated redirects file: [drivers-redirects.txt](https://github.com/mongodb/docs-ecosystem/files/6103518/drivers-redirects.txt)
