### PR TITLE
DOP-1883: update TOC link to use canonical node docs URL

### DIFF
--- a/source/index.txt
+++ b/source/index.txt
@@ -18,7 +18,7 @@ MongoDB Drivers
    C# and .NET Driver </csharp>
    Go Driver </go>
    Java Drivers </java-drivers>
-   Node.js Driver <https://docs.mongodb.com/drivers/node>
+   Node.js Driver <https://docs.mongodb.com/drivers/node/current/>
    PHP Driver </php>
    Python Drivers </python>
    Ruby Driver  <https://docs.mongodb.com/ruby-driver/current/>


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOP-1883

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodborg-staging.corp.mongodb.com/85ec5ca/drivers/docsworker-xlarge/trivial-node-TOC/

### Log
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=605a40cd2723a9e448ebc55c