### PR TITLE
DOCS-14405: Update golang instructions for libmongocrypt

### DIFF
--- a/source/security/client-side-field-level-encryption-guide.txt
+++ b/source/security/client-side-field-level-encryption-guide.txt
@@ -13,8 +13,8 @@ Who Is This Guide For?
 
 This guide shows you how to implement automatic Client-Side Field Level
 Encryption (CSFLE) using supported MongoDB drivers and is intended for
-**full-stack developers**. The guide presents the following
-information in the context of a real-world scenario:
+**full-stack developers**. You can read information on the following
+topics in the context of a real-world scenario:
 
 - :ref:`Introduction <csfle-guide-intro>`: How Client-Side Field Level
   Encryption works
@@ -30,10 +30,10 @@ information in the context of a real-world scenario:
 
 Once you complete the steps in this guide, you should have:
 
-- an understanding of how client-side field level encryption works and
+- An understanding of how client-side field level encryption works and
   in what situations it is practical
-- a working client application that demonstrates automatic CSFLE
-- resources on how to move the sample client application to production
+- A working client application that demonstrates automatic CSFLE
+- Resources on how to move the sample client application to production
 
 .. _csfle-guide-intro:
 
@@ -245,6 +245,8 @@ Additional Dependencies
          * - `mongodb-client-encryption
              <https://www.npmjs.com/package/mongodb-client-encryption>`_
            - NodeJS wrapper for the ``libmongocrypt`` encryption library.
+             The ``libmongocrypt`` library contains bindings to communicate
+             with the native library that manages the encryption.
 
          * - `uuid-base64
              <https://www.npmjs.com/package/uuid-base64#installation>`_
@@ -262,6 +264,8 @@ Additional Dependencies
          * - `pymongocrypt
              <https://pypi.org/project/pymongocrypt/>`_
            - Python wrapper for the ``libmongocrypt`` encryption library.
+             The ``libmongocrypt`` library contains bindings to communicate
+             with the native library that manages the encryption.
 
    .. tab::
       :tabid: csharp
@@ -281,7 +285,7 @@ Additional Dependencies
 
       .. list-table::
          :header-rows: 1
-         :widths: 40 60
+         :widths: 30 70
 
          * - Dependency Name
            - Description
@@ -291,8 +295,10 @@ Additional Dependencies
              `go module support <https://blog.golang.org/using-go-modules>`__.
 
          * - `libmongocrypt <https://github.com/mongodb/libmongocrypt#libmongocrypt>`__ version 1.1.0 or later
-           -
-
+              See the `mongo package Client Side Encryption guide <https://pkg.go.dev/go.mongodb.org/mongo-driver/mongo#hdr-Client_Side_Encryption>`__
+              for installation instructions.
+           - The ``libmongocrypt`` library contains bindings to communicate
+             with the native library that manages the encryption.
 
 .. _fle-create-a-master-key:
 
@@ -755,7 +761,7 @@ can provide configurable parameters including:
       .. list-table::
          :header-rows: 1
          :stub-columns: 1
-         :widths: 40 60
+         :widths: 30 70
 
          * - Name
            - Description
@@ -1373,8 +1379,8 @@ For more information on securing your master key, see our :doc:`step-by-step
 guide to integrating with Amazon KMS
 </security/client-side-field-level-encryption-local-key-to-kms/>`.
 
-Further Reading
-~~~~~~~~~~~~~~~
+Learn More
+~~~~~~~~~~
 
 For more information on client-side field level encryption in MongoDB,
 check out the reference docs in the server manual:

--- a/source/security/client-side-field-level-encryption-guide.txt
+++ b/source/security/client-side-field-level-encryption-guide.txt
@@ -294,12 +294,10 @@ Additional Dependencies
            - A Go version of 1.10 or later is required. Go 1.11 or later is recommended for support
              `go module support <https://blog.golang.org/using-go-modules>`__.
 
-         * - `libmongocrypt <https://github.com/mongodb/libmongocrypt#libmongocrypt>`__ version 1.1.0 or later
-
+           - `libmongocrypt <https://pkg.go.dev/go.mongodb.org/mongo-driver/mongo#hdr-Client_Side_Encryption>`__
+             version 1.1.0 or later
            - The ``libmongocrypt`` library contains bindings to communicate
-             with the native library that manages the encryption. See the
-             `mongo package Client Side Encryption guide <https://pkg.go.dev/go.mongodb.org/mongo-driver/mongo#hdr-Client_Side_Encryption>`__
-             for installation instructions.
+             with the native library that manages the encryption.
 
 .. _fle-create-a-master-key:
 

--- a/source/security/client-side-field-level-encryption-guide.txt
+++ b/source/security/client-side-field-level-encryption-guide.txt
@@ -294,7 +294,7 @@ Additional Dependencies
            - A Go version of 1.10 or later is required. Go 1.11 or later is recommended for support
              `go module support <https://blog.golang.org/using-go-modules>`__.
 
-           - `libmongocrypt <https://pkg.go.dev/go.mongodb.org/mongo-driver/mongo#hdr-Client_Side_Encryption>`__
+         * - `libmongocrypt <https://pkg.go.dev/go.mongodb.org/mongo-driver/mongo#hdr-Client_Side_Encryption>`__
              version 1.1.0 or later
            - The ``libmongocrypt`` library contains bindings to communicate
              with the native library that manages the encryption.

--- a/source/security/client-side-field-level-encryption-guide.txt
+++ b/source/security/client-side-field-level-encryption-guide.txt
@@ -218,7 +218,7 @@ Additional Dependencies
 
       .. list-table::
          :header-rows: 1
-         :widths: 40 60
+         :widths: 30 70
 
          * - Dependency Name
            - Description
@@ -237,7 +237,7 @@ Additional Dependencies
 
       .. list-table::
          :header-rows: 1
-         :widths: 40 60
+         :widths: 30 70
 
          * - Dependency Name
            - Description
@@ -256,7 +256,7 @@ Additional Dependencies
 
       .. list-table::
          :header-rows: 1
-         :widths: 40 60
+         :widths: 30 70
 
          * - Dependency Name
            - Description
@@ -272,7 +272,7 @@ Additional Dependencies
 
       .. list-table::
          :header-rows: 1
-         :widths: 40 60
+         :widths: 30 70
 
          * - Dependency Name
            - Description
@@ -295,10 +295,11 @@ Additional Dependencies
              `go module support <https://blog.golang.org/using-go-modules>`__.
 
          * - `libmongocrypt <https://github.com/mongodb/libmongocrypt#libmongocrypt>`__ version 1.1.0 or later
-              See the `mongo package Client Side Encryption guide <https://pkg.go.dev/go.mongodb.org/mongo-driver/mongo#hdr-Client_Side_Encryption>`__
-              for installation instructions.
+
            - The ``libmongocrypt`` library contains bindings to communicate
-             with the native library that manages the encryption.
+             with the native library that manages the encryption. See the
+             `mongo package Client Side Encryption guide <https://pkg.go.dev/go.mongodb.org/mongo-driver/mongo#hdr-Client_Side_Encryption>`__
+             for installation instructions.
 
 .. _fle-create-a-master-key:
 
@@ -812,7 +813,7 @@ can provide configurable parameters including:
       .. list-table::
          :header-rows: 1
          :stub-columns: 1
-         :widths: 40 60
+         :widths: 30 70
 
          * - Name
            - Description
@@ -861,7 +862,7 @@ can provide configurable parameters including:
       .. list-table::
          :header-rows: 1
          :stub-columns: 1
-         :widths: 40 60
+         :widths: 30 70
 
          * - Name
            - Description
@@ -896,7 +897,7 @@ can provide configurable parameters including:
       .. list-table::
          :header-rows: 1
          :stub-columns: 1
-         :widths: 40 60
+         :widths: 30 70
 
          * - Name
            - Description
@@ -941,7 +942,7 @@ can provide configurable parameters including:
       .. list-table::
          :header-rows: 1
          :stub-columns: 1
-         :widths: 40 60
+         :widths: 30 70
 
          * - Name
            - Description

--- a/source/security/client-side-field-level-encryption-guide.txt
+++ b/source/security/client-side-field-level-encryption-guide.txt
@@ -13,7 +13,7 @@ Who Is This Guide For?
 
 This guide shows you how to implement automatic Client-Side Field Level
 Encryption (CSFLE) using supported MongoDB drivers and is intended for
-**full-stack developers**. You can read information on the following
+**full-stack developers**. You can read information about the following
 topics in the context of a real-world scenario:
 
 - :ref:`Introduction <csfle-guide-intro>`: How Client-Side Field Level


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCS-14405

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/598ea83/drivers/docsworker-xlarge/DOCS-14405-CSFLE-libmongocrypt/security/client-side-field-level-encryption-guide/
