### PR TITLE
DOCSP-17382 connecting to serverless

### DIFF
--- a/source/c.txt
+++ b/source/c.txt
@@ -72,6 +72,8 @@ Connect to MongoDB Atlas
       return 0;
    }
 
+.. include:: /includes/serverless-compatibility.rst
+
 See `Advanced Connections <http://mongoc.org/libmongoc/current/advanced-connections.html>`__
 for more ways to connect.
 
@@ -82,8 +84,6 @@ Connect to ``localhost``
 
 Compatibility
 -------------
-
-.. include:: /includes/serverless-compatibility.rst
 
 MongoDB Compatibility
 ~~~~~~~~~~~~~~~~~~~~~

--- a/source/c.txt
+++ b/source/c.txt
@@ -83,6 +83,8 @@ Connect to ``localhost``
 Compatibility
 -------------
 
+.. include:: /includes/serverless-compatibility.rst
+
 MongoDB Compatibility
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/csharp.txt
+++ b/source/csharp.txt
@@ -76,6 +76,8 @@ Connect to ``localhost``
 Compatibility
 -------------
 
+.. include:: /includes/serverless-compatibility.rst
+
 MongoDB Compatibility
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/csharp.txt
+++ b/source/csharp.txt
@@ -65,6 +65,8 @@ Connect to MongoDB Atlas
    );
    var database = client.GetDatabase("test");
 
+.. include:: /includes/serverless-compatibility.rst
+
 See `Connecting <https://mongodb.github.io/mongo-csharp-driver/2.12/reference/driver/connecting/>`__
 for more information.
 
@@ -75,8 +77,6 @@ Connect to ``localhost``
 
 Compatibility
 -------------
-
-.. include:: /includes/serverless-compatibility.rst
 
 MongoDB Compatibility
 ~~~~~~~~~~~~~~~~~~~~~

--- a/source/cxx.txt
+++ b/source/cxx.txt
@@ -64,6 +64,8 @@ Connect to ``localhost``
 Compatibility
 -------------
 
+.. include:: /includes/serverless-compatibility.rst
+
 MongoDB Compatibility
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/cxx.txt
+++ b/source/cxx.txt
@@ -56,6 +56,8 @@ Connect to MongoDB Atlas
    };
    mongocxx::database db = conn["test"];
 
+.. include:: /includes/serverless-compatibility.rst
+
 Connect to ``localhost``
 ------------------------
 
@@ -63,8 +65,6 @@ Connect to ``localhost``
 
 Compatibility
 -------------
-
-.. include:: /includes/serverless-compatibility.rst
 
 MongoDB Compatibility
 ~~~~~~~~~~~~~~~~~~~~~

--- a/source/go.txt
+++ b/source/go.txt
@@ -64,6 +64,8 @@ Connect to ``localhost``
 Compatibility
 -------------
 
+.. include:: /includes/serverless-compatibility.rst
+
 MongoDB Compatibility
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/go.txt
+++ b/source/go.txt
@@ -53,6 +53,8 @@ Connect to MongoDB Atlas
 .. literalinclude:: /includes/connection-snippets/go-connection.go
    :language: go
 
+.. include:: /includes/serverless-compatibility.rst
+
 See `Usage <https://github.com/mongodb/mongo-go-driver#usage>`__
 for more detail.
 
@@ -63,8 +65,6 @@ Connect to ``localhost``
 
 Compatibility
 -------------
-
-.. include:: /includes/serverless-compatibility.rst
 
 MongoDB Compatibility
 ~~~~~~~~~~~~~~~~~~~~~

--- a/source/includes/serverless-compatibility.rst
+++ b/source/includes/serverless-compatibility.rst
@@ -1,0 +1,6 @@
+.. note::
+
+    To connect to a serverless instance, see the :manual:`Serverless
+    Instance Limitations page
+    </reference/serverless-instance-limitations/#minimum-driver-versions-for-serverless-instances>`
+    for the minimum driver version you need. 

--- a/source/includes/serverless-compatibility.rst
+++ b/source/includes/serverless-compatibility.rst
@@ -1,6 +1,6 @@
 .. note::
 
-    To connect to Atlas Serverless, see the :atlas:`Serverless
-    Instance Limitations page
+    For information about connecting to Atlas Serverless, see the
+    :atlas:`Serverless Instance Limitations page
     </reference/serverless-instance-limitations/#minimum-driver-versions-for-serverless-instances>`
     for the minimum driver version you need. 

--- a/source/includes/serverless-compatibility.rst
+++ b/source/includes/serverless-compatibility.rst
@@ -1,6 +1,6 @@
 .. note::
 
-    To connect to a serverless instance, see the :atlas:`Serverless
+    To connect to Atlas Serverless, see the :atlas:`Serverless
     Instance Limitations page
     </reference/serverless-instance-limitations/#minimum-driver-versions-for-serverless-instances>`
     for the minimum driver version you need. 

--- a/source/includes/serverless-compatibility.rst
+++ b/source/includes/serverless-compatibility.rst
@@ -1,6 +1,6 @@
 .. note::
 
-    To connect to a serverless instance, see the :manual:`Serverless
+    To connect to a serverless instance, see the :atlas:`Serverless
     Instance Limitations page
     </reference/serverless-instance-limitations/#minimum-driver-versions-for-serverless-instances>`
     for the minimum driver version you need. 

--- a/source/java.txt
+++ b/source/java.txt
@@ -76,14 +76,13 @@ Connect to MongoDB Atlas
    MongoClient mongoClient = MongoClients.create(settings);
    MongoDatabase database = mongoClient.getDatabase("test");
 
+.. include:: /includes/serverless-compatibility.rst
+
 See :java-docs:`Connect to MongoDB <driver/tutorials/connect-to-mongodb/>`
 for more ways to connect.
 
-
 Compatibility
 -------------
-
-.. include:: /includes/serverless-compatibility.rst
 
 MongoDB Compatibility
 ~~~~~~~~~~~~~~~~~~~~~

--- a/source/java.txt
+++ b/source/java.txt
@@ -83,6 +83,8 @@ for more ways to connect.
 Compatibility
 -------------
 
+.. include:: /includes/serverless-compatibility.rst
+
 MongoDB Compatibility
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/motor.txt
+++ b/source/motor.txt
@@ -116,6 +116,8 @@ following code to connect:
 
    tornado.ioloop.IOLoop.current().run_sync(get_server_info)
 
+.. include:: /includes/serverless-compatibility.rst
+
 If the connection succeeds before a five-second timeout, you will see a
 dictionary containing information about the server you connected to.
 
@@ -136,8 +138,6 @@ Connect to ``localhost``
 
 Compatibility
 -------------
-
-.. include:: /includes/serverless-compatibility.rst
 
 MongoDB Compatibility
 ~~~~~~~~~~~~~~~~~~~~~

--- a/source/motor.txt
+++ b/source/motor.txt
@@ -137,6 +137,8 @@ Connect to ``localhost``
 Compatibility
 -------------
 
+.. include:: /includes/serverless-compatibility.rst
+
 MongoDB Compatibility
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/motor.txt
+++ b/source/motor.txt
@@ -11,7 +11,7 @@ Motor (Async Driver)
 .. contents:: On this page
    :local:
    :backlinks: none
-   :depth: 2
+   :depth: 1
    :class: twocols
 
 Introduction

--- a/source/php.txt
+++ b/source/php.txt
@@ -111,6 +111,8 @@ Connect to MongoDB Atlas
 
    $db = $client->test;
 
+.. include:: /includes/serverless-compatibility.rst
+
 Connect to ``localhost``
 ------------------------
 
@@ -124,8 +126,6 @@ users are advised to use 64-bit environments. When using a 32-bit platform, be
 aware that any 64-bit integer read from the database will be returned as a
 `MongoDB\\BSON\\Int64 <https://www.php.net/manual/en/class.mongodb-bson-int64.php>`_
 instance instead of a PHP integer type.
-
-.. include:: /includes/serverless-compatibility.rst
 
 MongoDB Compatibility
 ~~~~~~~~~~~~~~~~~~~~~

--- a/source/php.txt
+++ b/source/php.txt
@@ -125,6 +125,8 @@ aware that any 64-bit integer read from the database will be returned as a
 `MongoDB\\BSON\\Int64 <https://www.php.net/manual/en/class.mongodb-bson-int64.php>`_
 instance instead of a PHP integer type.
 
+.. include:: /includes/serverless-compatibility.rst
+
 MongoDB Compatibility
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/pymongo.txt
+++ b/source/pymongo.txt
@@ -107,6 +107,8 @@ Connect to ``localhost``
 Compatibility
 -------------
 
+.. include:: /includes/serverless-compatibility.rst
+
 MongoDB Compatibility
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/pymongo.txt
+++ b/source/pymongo.txt
@@ -9,7 +9,7 @@ PyMongo
 .. contents:: On this page
    :local:
    :backlinks: none
-   :depth: 2
+   :depth: 1
    :class: singlecol
 
 Introduction

--- a/source/pymongo.txt
+++ b/source/pymongo.txt
@@ -86,6 +86,8 @@ Connect to MongoDB Atlas
    except Exception:
        print("Unable to connect to the server.")
 
+.. include:: /includes/serverless-compatibility.rst
+
 If the connection succeeds before a five-second timeout, you will see a
 dictionary containing information about the server you connected to.
 
@@ -106,8 +108,6 @@ Connect to ``localhost``
 
 Compatibility
 -------------
-
-.. include:: /includes/serverless-compatibility.rst
 
 MongoDB Compatibility
 ~~~~~~~~~~~~~~~~~~~~~

--- a/source/reactive-streams.txt
+++ b/source/reactive-streams.txt
@@ -71,6 +71,8 @@ Connect to ``localhost``
 Compatibility
 -------------
 
+.. include:: /includes/serverless-compatibility.rst
+
 MongoDB Compatibility
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/reactive-streams.txt
+++ b/source/reactive-streams.txt
@@ -60,6 +60,8 @@ Connect to MongoDB Atlas
    MongoClient mongoClient = MongoClients.create(settings);
    MongoDatabase database = mongoClient.getDatabase("test");
 
+.. include:: /includes/serverless-compatibility.rst
+
 See :java-docs:`Connect to MongoDB <driver-reactive/tutorials/connect-to-mongodb/>`
 for more ways to connect.
 
@@ -70,8 +72,6 @@ Connect to ``localhost``
 
 Compatibility
 -------------
-
-.. include:: /includes/serverless-compatibility.rst
 
 MongoDB Compatibility
 ~~~~~~~~~~~~~~~~~~~~~

--- a/source/rust.txt
+++ b/source/rust.txt
@@ -112,6 +112,8 @@ corresponding connection code samples.
              Ok(())
          }
 
+.. include:: /includes/serverless-compatibility.rst
+
 Connect to ``localhost``
 ------------------------
 
@@ -119,8 +121,6 @@ Connect to ``localhost``
 
 Compatibility
 -------------
-
-.. include:: /includes/serverless-compatibility.rst
 
 MongoDB Compatibility
 ~~~~~~~~~~~~~~~~~~~~~

--- a/source/rust.txt
+++ b/source/rust.txt
@@ -120,6 +120,8 @@ Connect to ``localhost``
 Compatibility
 -------------
 
+.. include:: /includes/serverless-compatibility.rst
+
 MongoDB Compatibility
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/scala.txt
+++ b/source/scala.txt
@@ -69,6 +69,8 @@ Connect to ``localhost``
 Compatibility
 -------------
 
+.. include:: /includes/serverless-compatibility.rst
+
 MongoDB Compatibility
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/scala.txt
+++ b/source/scala.txt
@@ -58,6 +58,8 @@ Connect to MongoDB Atlas
    val client: MongoClient = MongoClient(uri)
    val db: MongoDatabase = client.getDatabase("test")
 
+.. include:: /includes/serverless-compatibility.rst
+
 See our guide on :java-docs:`Connecting <driver-scala/tutorials/connect-to-mongodb/>`
 for more ways to connect.
 
@@ -68,8 +70,6 @@ Connect to ``localhost``
 
 Compatibility
 -------------
-
-.. include:: /includes/serverless-compatibility.rst
 
 MongoDB Compatibility
 ~~~~~~~~~~~~~~~~~~~~~

--- a/source/swift.txt
+++ b/source/swift.txt
@@ -85,6 +85,8 @@ Connect to MongoDB Atlas
 
          // your application logic
 
+.. include:: /includes/serverless-compatibility.rst
+
 Connect to ``localhost``
 ------------------------
 
@@ -92,8 +94,6 @@ Connect to ``localhost``
 
 Compatibility
 -------------
-
-.. include:: /includes/serverless-compatibility.rst
 
 MongoDB Compatibility
 ~~~~~~~~~~~~~~~~~~~~~

--- a/source/swift.txt
+++ b/source/swift.txt
@@ -93,6 +93,8 @@ Connect to ``localhost``
 Compatibility
 -------------
 
+.. include:: /includes/serverless-compatibility.rst
+
 MongoDB Compatibility
 ~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
## Pull Request Info

Added a note to redirect readers to the atlas page about connecting to a serverless instance.

Once approved here, I'll create a PR for the Node.js and Java driver docs repos.

Note: the link to the atlas page does not work yet, but here is their current link in staging: https://docs-atlas-staging.mongodb.com/cloud-docs/docsworker-xlarge/DOCSP-15986/reference/serverless-instance-limitations/#minimum-driver-versions-for-serverless-instances  

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-DOCSP-17382

### Docs staging link (requires sign-in on MongoDB Corp SSO):

https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/DOCSP-17382-ServerlessCompatibility/c/#connect-to-mongodb-atlas

https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/DOCSP-17382-ServerlessCompatibility/cxx/#connect-to-mongodb-atlas

https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/DOCSP-17382-ServerlessCompatibility/csharp/#connect-to-mongodb-atlas

https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/DOCSP-17382-ServerlessCompatibility/go/#connect-to-mongodb-atlas

https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/DOCSP-17382-ServerlessCompatibility/java/#connect-to-mongodb-atlas

https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/DOCSP-17382-ServerlessCompatibility/reactive-streams/#connect-to-mongodb-atlas

https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/DOCSP-17382-ServerlessCompatibility/php/#connect-to-mongodb-atlas

https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/DOCSP-17382-ServerlessCompatibility/pymongo/#connect-to-mongodb-atlas

https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/DOCSP-17382-ServerlessCompatibility/motor/#connect-to-mongodb-atlas

https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/DOCSP-17382-ServerlessCompatibility/scala/#connect-to-mongodb-atlas

https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/DOCSP-17382-ServerlessCompatibility/swift/#connect-to-mongodb-atlas

https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/DOCSP-17382-ServerlessCompatibility/rust/#connect-to-mongodb-atlas
