### PR TITLE
DOCSP-17290: expose java/sync

### DIFF
--- a/source/java-drivers.txt
+++ b/source/java-drivers.txt
@@ -20,7 +20,7 @@ Java MongoDB Drivers
 Introduction
 ------------
 
-:doc:`Java Driver </java>` is the recommended MongoDB Java Driver.
+`Java Driver <https://docs.mongodb.com/drivers/java/sync/current>`__ is the recommended MongoDB Java Driver.
 
 For asynchronous stream processing and reactive streams interoperability,
 the :doc:`Reactive Streams Driver </reactive-streams>` is the

--- a/source/java.txt
+++ b/source/java.txt
@@ -1,34 +1,30 @@
 .. _java-language-center:
 
-.. include:: /includes/unicode-checkmark.rst
-
-===================
-Java MongoDB Driver
-===================
+====================
+Java MongoDB Drivers
+====================
 
 .. default-domain:: mongodb
+
+.. toctree::
+   :titlesonly:
+
+   /java.txt
+   /reactive-streams.txt
 
 .. contents:: On this page
    :local:
    :backlinks: none
    :depth: 1
-   :class: twocols
 
 Introduction
 ------------
 
-The official MongoDB Java Driver providing both synchronous and asynchronous interaction with MongoDB.
+`Java Driver <https://docs.mongodb.com/drivers/java/sync/current>`__ is the recommended MongoDB Java Driver.
 
-- :java-docs:`Reference Documentation <driver/>`
-
-- :java-docs:`Tutorials <driver/tutorials/>`
-
-- :java-docs:`API Documentation <apidocs/>`
-
-- :java-docs:`What's New <whats-new/>`
-
-- `Source Code <https://github.com/mongodb/mongo-java-driver/>`__
-
+For asynchronous stream processing and reactive streams interoperability,
+the :doc:`Reactive Streams Driver </reactive-streams>` is the
+recommended MongoDB Java Driver.
 
 Take the free online course taught by MongoDB
 ---------------------------------------------
@@ -44,60 +40,3 @@ Take the free online course taught by MongoDB
        Learn the essentials of Java application development with MongoDB.
 
 
-Installation
-------------
-
-The recommended way to get started using one of the drivers in your project is with a dependency
-management system. See the :java-docs:`Installation Guide <driver/getting-started/installation/>`
-for more information.
-
-
-Connect to MongoDB Atlas
-------------------------
-
-.. include:: /includes/atlas-connect-blurb.rst
-
-.. code-block:: java
-
-   import com.mongodb.ConnectionString;
-   import com.mongodb.client.MongoClients;
-   import com.mongodb.client.MongoClient;
-   import com.mongodb.client.MongoDatabase;
-   import com.mongodb.MongoClientSettings;
-
-   // ...
-   ConnectionString connString = new ConnectionString(
-       "mongodb+srv://<username>:<password>@<cluster-address>/test?w=majority"
-   );
-   MongoClientSettings settings = MongoClientSettings.builder()
-       .applyConnectionString(connString)
-       .retryWrites(true)
-       .build();
-   MongoClient mongoClient = MongoClients.create(settings);
-   MongoDatabase database = mongoClient.getDatabase("test");
-
-.. include:: /includes/serverless-compatibility.rst
-
-See :java-docs:`Connect to MongoDB <driver/tutorials/connect-to-mongodb/>`
-for more ways to connect.
-
-Compatibility
--------------
-
-MongoDB Compatibility
-~~~~~~~~~~~~~~~~~~~~~
-
-.. include:: /includes/mongodb-compatibility-table-java.rst
-
-.. include:: /includes/older-server-versions-unsupported.rst
-
-Language Compatibility
-~~~~~~~~~~~~~~~~~~~~~~
-
-.. include:: /includes/extracts/java-driver-compatibility-matrix-language.rst
-
-.. include:: /includes/language-compatibility-table-java.rst
-
-.. include:: /includes/about-driver-compatibility.rst
-
-.. include:: /includes/help-links-java.rst

--- a/source/java.txt
+++ b/source/java.txt
@@ -6,12 +6,6 @@ Java MongoDB Drivers
 
 .. default-domain:: mongodb
 
-.. toctree::
-   :titlesonly:
-
-   /java.txt
-   /reactive-streams.txt
-
 .. contents:: On this page
    :local:
    :backlinks: none


### PR DESCRIPTION
## Pull Request Info

This makes the /java page the same as /java-drivers and updates the link to the new /java/sync site for the standard java driver

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-17290

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/DOCSP-17290/java-drivers/