### PR TITLE
PHPC-1685 and PHPLIB-589: ext-1.10 and lib-1.9 do not support PHP 7.0

### DIFF
--- a/source/includes/language-compatibility-table-php.rst
+++ b/source/includes/language-compatibility-table-php.rst
@@ -21,7 +21,7 @@
      - |checkmark|
      - |checkmark|
      - |checkmark|
-     - |checkmark|
+     -
      -
      -
 


### PR DESCRIPTION
## Pull Request Info
A user reported this in https://github.com/mongodb/mongo-php-library/issues/845

### Issue JIRA link:
https://jira.mongodb.org/browse/PHPC-1685
https://jira.mongodb.org/browse/PHPLIB-589