### PR TITLE
DOCSP-17734 go compatibility table

### DIFF
--- a/source/includes/mongodb-compatibility-table-go.rst
+++ b/source/includes/mongodb-compatibility-table-go.rst
@@ -14,6 +14,17 @@
      - MongoDB 3.0
      - MongoDB 2.6
 
+   * - 1.7
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+
    * - 1.6
      - |checkmark| [#go-1.6-driver-support]_
      - |checkmark|


### PR DESCRIPTION
## Pull Request Info
Updated the Go-lang compatibility to include v1.7

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-17734

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/DOCSP-17734-Go1.7Compatibility/go/#compatibility
