### PR TITLE
fixes go link

### DIFF
--- a/source/security/client-side-field-level-encryption-guide.txt
+++ b/source/security/client-side-field-level-encryption-guide.txt
@@ -1364,7 +1364,7 @@ To view and download a runnable example of CSFLE, select your driver below:
       :tabid: go
 
       **GitHub:** `Go CSFLE runnable example
-      <https://github.com/mongodb-university/csfle-guides/tree/master/gocse>`__
+      <https://github.com/mongodb-university/csfle-guides/tree/master/go>`__
 
 Move to Production
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Pull Request Info

This fixes the broken link to the go project.

### Issue JIRA link:
n/a

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/fix-go-link/security/client-side-field-level-encryption-guide/#download-example-project
