### PR TITLE
DOCSP-18192: add new version to compat table

### DIFF
--- a/source/includes/mongodb-compatibility-table-c.rst
+++ b/source/includes/mongodb-compatibility-table-c.rst
@@ -14,6 +14,17 @@
      - MongoDB 3.0
      - MongoDB 2.6
 
+   * - 1.19
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     -
+
    * - 1.18
      - |checkmark| [#c-1.18-driver-support]_
      - |checkmark|
@@ -24,7 +35,7 @@
      - |checkmark|
      - |checkmark|
      -
-   
+
    * - 1.17
      -
      - |checkmark|
@@ -224,4 +235,4 @@
      - |checkmark|
 
 .. [#c-1.18-driver-support] The 1.18 driver does not support snapshot reads on secondaries. For more
-   information, see the `MongoDB Server version 5.0 release notes <https://docs.mongodb.com/v5.0/release-notes/5.0/#snapshots>`__. 
+   information, see the `MongoDB Server version 5.0 release notes <https://docs.mongodb.com/v5.0/release-notes/5.0/#snapshots>`__.


### PR DESCRIPTION
## Pull Request Info

Adds version 1.19 with full 5.0 support.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-18192

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/DOCSP-18192/c/#compatibility
