### PR TITLE
DOCS-14648 CSFLE template clarification

### DIFF
--- a/source/includes/steps-fle-convert-to-a-remote-master-key-aws.yaml
+++ b/source/includes/steps-fle-convert-to-a-remote-master-key-aws.yaml
@@ -74,6 +74,8 @@ content: |
 
   2. Next, add your authentication credentials to your CSFLE-enabled client
      code:
+     
+  .. include:: /includes/substitute-placeholders.rst
 
   .. tabs-drivers::
 
@@ -195,7 +197,9 @@ content: |
 
   2. Once you have the required information, update and run the following code
      to generate the new data encryption key:
-
+     
+  .. include:: /includes/substitute-placeholders.rst
+  
   .. tabs-drivers::
 
      .. tab::

--- a/source/includes/steps-fle-convert-to-a-remote-master-key-azure.yaml
+++ b/source/includes/steps-fle-convert-to-a-remote-master-key-azure.yaml
@@ -81,6 +81,8 @@ content: |
   2. Next, update the KMS Provider configuration in your CSFLE-enabled client
      creation code:
 
+     .. include:: /includes/substitute-placeholders.rst
+
      .. tabs-drivers::
 
         .. tab::
@@ -247,6 +249,8 @@ content: |
   2. Once you have the required information, update and run the following code
      to generate a new data encryption key:
 
+     .. include:: /includes/substitute-placeholders.rst
+     
      .. tabs-drivers::
 
         .. tab::

--- a/source/includes/steps-fle-convert-to-a-remote-master-key-gcp.yaml
+++ b/source/includes/steps-fle-convert-to-a-remote-master-key-gcp.yaml
@@ -91,6 +91,8 @@ content: |
 
   2. Next, add your authentication credentials to your CSFLE-enabled client
      code:
+      
+     .. include:: /includes/substitute-placeholders.rst
 
      .. tabs-drivers::
 
@@ -256,6 +258,8 @@ content: |
   2. Once you have the required information, update and run the following code
      to generate a new data encryption key:
 
+     .. include:: /includes/substitute-placeholders.rst
+     
      .. tabs-drivers::
 
         .. tab::

--- a/source/includes/substitute-placeholders.rst
+++ b/source/includes/substitute-placeholders.rst
@@ -1,0 +1,5 @@
+.. note::
+
+    If your language isn't using enviornment variables, you must
+    substitute all values in quotes with angle brackets with your KMS
+    configuration values. 

--- a/source/includes/substitute-placeholders.rst
+++ b/source/includes/substitute-placeholders.rst
@@ -3,15 +3,18 @@
     You must substitute all text in quotes and angle brackets with
     your KMS configuration values. 
 
-    For example, the Node.js code prompts you to include email as follows:
+    For example, the Node.js code prompts you to include an email as
+    follows: 
 
     .. code-block:: javascript
+       :copyable: false
 
         email: "<GCP service account email>"
     
-    Your GCP service accoutn email is "someEmail@email.com", you should
-    replace the text in the following code snippet as follows: 
+    If your GCP service account email is "someEmail@email.com", you should
+    substitute the text as follows: 
 
     .. code-block:: javascript
+       :copyable: false
 
         email: "someEmail@email.com"

--- a/source/includes/substitute-placeholders.rst
+++ b/source/includes/substitute-placeholders.rst
@@ -1,5 +1,4 @@
 .. note::
 
-    If your language isn't using enviornment variables, you must
-    substitute all values in quotes with angle brackets with your KMS
-    configuration values. 
+    You must substitute all values in quotes with angle brackets with
+    your KMS configuration values. 

--- a/source/includes/substitute-placeholders.rst
+++ b/source/includes/substitute-placeholders.rst
@@ -1,4 +1,17 @@
-.. note::
+.. note:: Placeholder Text
 
-    You must substitute all values in quotes with angle brackets with
+    You must substitute all text in quotes and angle brackets with
     your KMS configuration values. 
+
+    For example, the Node.js code prompts you to include email as follows:
+
+    .. code-block:: javascript
+
+        email: "<GCP service account email>"
+    
+    Your GCP service accoutn email is "someEmail@email.com", you should
+    replace the text in the following code snippet as follows: 
+
+    .. code-block:: javascript
+
+        email: "someEmail@email.com"


### PR DESCRIPTION
## Pull Request Info
Added note about substitution needed on the CSFLE KMS page.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-14648

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=612d35177dcf0129302b8f35

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/DOCS-14648-CSFLETemplateClarification/security/client-side-field-level-encryption-local-key-to-kms/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?
