### PR TITLE
redirect to new docset

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -4,6 +4,9 @@ define: manual https://docs.mongodb.com/manual
 define: atlas https://docs.atlas.mongodb.com
 define: devhub https://developer.mongodb.com
 
+# Go
+raw: drivers/go -> ${base}/go/current/
+
 # Java
 raw: drivers/java -> ${base}/java-drivers/
 

--- a/config/redirects
+++ b/config/redirects
@@ -54,7 +54,7 @@ raw: drivers/tutorial/use-java-dbobject-to-perform-saves -> ${base}/java/
 raw: drivers/tutorial/authenticate-with-java-driver/ -> http://mongodb.github.io/mongo-java-driver/3.0/driver/reference/connecting/authenticating
 
 # nodejs
-raw: drivers/javascript -> ${base}/node/
+raw: drivers/javascript -> ${base}/node/current/
 
 # ruby and mongoid
 raw: drivers/tutorial/getting-started-with-ruby-on-rails-3 -> https://docs.mongodb.com/ruby-driver/current/tutorials/bson-v4/


### PR DESCRIPTION
## Pull Request Info

This redirects drivers/go to drivers/go/current/ and into the new docset.

### Issue JIRA link:
N/A

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=6144eca1c608bec57f3c4fa7

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodborg-staging.corp.mongodb.com/ecosystem/docsworker/NNNNN/index.html

### Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Does it render on staging correctly?
- [ ] Are all the links working?
- [ ] Are the staging and workerpool job links in the PR description updated?
