### PR TITLE
DOCSP-18828 rust order

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,10 @@
 ## Pull Request Info
 
 ### Issue JIRA link:
-https://jira.mongodb.org/browse/DOCSP-NNNN
+https://jira.mongodb.org/browse/DOCSP-NNNNN
+
+### Snooty Build log:
+**Paste your workerpool job link here**
 
 ### Docs staging link (requires sign-in on MongoDB Corp SSO):
-https://docs-mongodborg-staging.corp.mongodb.com/ecosystem/docsworker/NNNN/index.html
+https://docs-mongodborg-staging.corp.mongodb.com/ecosystem/docsworker/NNNNN/index.html

--- a/source/index.txt
+++ b/source/index.txt
@@ -23,8 +23,8 @@ MongoDB Drivers
    Python Drivers </python>
    Ruby Driver  <https://docs.mongodb.com/ruby-driver/current/>
    Ruby Mongoid ODM  <https://docs.mongodb.com/mongoid/current/>
+   Rust Driver </rust>
    Scala Driver </scala>
    Swift Driver </swift>
-   Rust Driver </rust>
    About Compatibility Tables <about-compatibility>
    Security </security>


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-18828

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=61536b498670bd27318f1519

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/DOCSP-18828-rust-order/rust/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?
