### PR TITLE
DOP-929: Update source/index.txt to reflect functionality

### DIFF
--- a/source/index.txt
+++ b/source/index.txt
@@ -14,7 +14,7 @@ The following libraries are officially supported by MongoDB. They are actively m
 
 .. drivers-index-tiles::
 
-Don’t see your desired language? Browse a list of `community supported libraries <https://docs.mongodb.com/ecosystem/drivers/community-supported-drivers/>`_.
+Don’t see your desired language? Browse a list of :doc:`community supported libraries </community-supported-drivers>`.
 
 .. toctree::
 


### PR DESCRIPTION
## Pull Request Info
[DOP-929](https://jira.mongodb.org/browse/DOP-929) tackles tech debt that was overwriting  the rST in `docs-ecosystem/source/index.txt`. New code will hand functionality back to the docs team for this file. This file needs to be updated accordingly. To be clear, this goal of this PR is NOT to make content changes, but rather to update the content such that no changes are reflected once the frontend begins to actively read from this file.

[The DOP-929 snooty-parser PR](https://github.com/mongodb/snooty-parser/pull/348/files) has already been made.
This should be merged BEFORE [the DOP-929 snooty-frontend PR](https://github.com/mongodb/snooty/pull/500), which will cause the frontend to actively read the rST in this file.

Before the frontend PR is merged, any changes to this file WILL NOT be propagated (thus, the staging link should be the exact same as the production link). After the frontend PR is merged, the changes to this file WILL be propagated. You can see those changes in staging [here](https://docs-mongodbcom-staging.corp.mongodb.com/DOP-929/drivers/cgoecknerwald/DOP-929/).

### Issue JIRA link:
https://jira.mongodb.org/browse/DOP-929

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=615e23758670bd2731706a2b

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/DOP-929/

### Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
No, it has a `ERROR(index.txt:14ish): Unknown directive type "drivers-index-tiles".` warning, which is expected (warning will resolve with snooty frontend update).
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?
