### PR TITLE
DOCSP-19329 swift compatibility table update

### DIFF
--- a/source/includes/mongodb-compatibility-table-swift.rst
+++ b/source/includes/mongodb-compatibility-table-swift.rst
@@ -4,12 +4,28 @@
    :class: compatibility-large
 
    * - Swift Driver Version
+     - MongoDB 5.0
      - MongoDB 4.4
      - MongoDB 4.2
      - MongoDB 4.0
      - MongoDB 3.6
 
+   * - 1.2.0
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+
+   * - 1.1.0
+     -
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+
    * - 1.0.0
+     -
      - |checkmark| (*)
      - |checkmark|
      - |checkmark|

--- a/source/includes/mongodb-compatibility-table-swift.rst
+++ b/source/includes/mongodb-compatibility-table-swift.rst
@@ -4,6 +4,7 @@
    :class: compatibility-large
 
    * - Swift Driver Version
+     - MongoDB 5.1
      - MongoDB 5.0
      - MongoDB 4.4
      - MongoDB 4.2
@@ -11,6 +12,7 @@
      - MongoDB 3.6
 
    * - 1.2.0
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -19,12 +21,14 @@
 
    * - 1.1.0
      -
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
 
    * - 1.0.0
+     -
      -
      - |checkmark| (*)
      - |checkmark|


### PR DESCRIPTION
## Pull Request Info

Updated the Swift compatibility table to include 1.1.0 and 1.2.0.
I also confirmed with Kaitlin for each versions compatibility. 

Note: I was told 1.2.0 will be released this week (maybe today), so I will wait till I see the release message before merging.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-19329

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=618aeb56c13055282d8125dc

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/DOCSP-19329-Swift1.1.0/swift/#compatibility

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?
