### PR TITLE
DOCSP-19644: Update PHP driver language and server compat tables

### DIFF
--- a/source/includes/language-compatibility-table-php.rst
+++ b/source/includes/language-compatibility-table-php.rst
@@ -6,6 +6,7 @@
    :class: compatibility-large
 
    * - PHP Driver Versions
+     - PHP 8.1
      - PHP 8.0
      - PHP 7.4
      - PHP 7.3
@@ -15,7 +16,19 @@
      - PHP 5.6
      - PHP 5.5
 
+   * - ext 1.12 + lib 1.11
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     -
+     -
+     -
+     -
+
    * - ext 1.11 + lib 1.10
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -26,6 +39,7 @@
      -
 
    * - ext 1.10 + lib 1.9
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -36,6 +50,7 @@
      -
 
    * - ext 1.9 + lib 1.8
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -47,6 +62,7 @@
 
    * - ext 1.8 + lib 1.7
      -
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -56,6 +72,7 @@
      -
 
    * - ext 1.7 + lib 1.6
+     -
      -
      - |checkmark|
      - |checkmark|
@@ -67,6 +84,7 @@
 
    * - ext 1.6 + lib 1.5
      -
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -76,6 +94,7 @@
      -
 
    * - ext 1.5 + lib 1.4
+     -
      -
      -
      - |checkmark|
@@ -89,6 +108,7 @@
      -
      -
      -
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -96,6 +116,7 @@
      - |checkmark|
 
    * - ext 1.3 + lib 1.2
+     -
      -
      -
      -

--- a/source/includes/mongodb-compatibility-table-php.rst
+++ b/source/includes/mongodb-compatibility-table-php.rst
@@ -15,7 +15,20 @@
      - MongoDB 3.0
      - MongoDB 2.6
 
+   * - ext 1.12 + lib 1.11
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     -
+     -
+     -
+     -
+
    * - ext 1.11 + lib 1.10
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|

--- a/source/php.txt
+++ b/source/php.txt
@@ -137,7 +137,7 @@ MongoDB Compatibility
 
 .. include:: /includes/extracts/php-driver-compatibility-matrix-mongodb.rst
 
-.. include:: /includes/php-mongodb-compatibility-table.rst
+.. include:: /includes/mongodb-compatibility-table-php.rst
 
 Language Compatibility
 ~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This also renames the server compatibility table to be consistent with the files for other drivers.

## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-19644

### Snooty build log:
N/A

### Docs staging link (requires sign-in on MongoDB Corp SSO):
N/A

### Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Does it render on staging correctly?
- [ ] Are all the links working?
- [ ] Are the staging and workerpool job links in the PR description updated?
