### PR TITLE
add patch version note

### DIFF
--- a/source/includes/language-compatibility-table-csharp.rst
+++ b/source/includes/language-compatibility-table-csharp.rst
@@ -16,7 +16,7 @@
      - .NET 4.8
      - .NET 4.7
      - .NET 4.6
-     - .NET 4.5
+     - .NET 4.5 [#4.5.2]_
 
    * - 2.13
      - |checkmark|
@@ -31,7 +31,7 @@
      - |checkmark|
      - |checkmark|
      - |checkmark|
-   
+
    * - 2.12
      - |checkmark|
      - |checkmark|
@@ -206,3 +206,5 @@ Versions 1.10 and 1.11 of the driver are compatible with .NET 3.5
 through 4.8 only.
 
 .. [#atlas-connection] When using .NET 5, you can't connect to Atlas clusters running MongoDB 4.0 due to a certificate issue.
+
+.. [#4.5.2] .NET/C# driver 2.8 to 2.13 requires .NET Framework 4.5.2 or higher.

--- a/source/includes/language-compatibility-table-csharp.rst
+++ b/source/includes/language-compatibility-table-csharp.rst
@@ -207,4 +207,4 @@ through 4.8 only.
 
 .. [#atlas-connection] When using .NET 5, you can't connect to Atlas clusters running MongoDB 4.0 due to a certificate issue.
 
-.. [#4.5.2] .NET/C# driver 2.8 to 2.13 requires .NET Framework 4.5.2 or higher.
+.. [#4.5.2] .NET/C# driver versions 2.8 to 2.13 requires .NET Framework 4.5.2 or higher.


### PR DESCRIPTION
## Pull Request Info

This adds a note that certain versions of the driver require a patch version of .Net 4.5. This has already been reviewed by the C# lead.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCS-14936

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=619685755314b0809f9f2aea

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/DOCSP-14936/csharp/#language-compatibility

### Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Does it render on staging correctly?
- [ ] Are all the links working?
- [ ] Are the staging and workerpool job links in the PR description updated?
