### PR TITLE
DOCS-14845: clarify swift driver usage and link to Realm iOS

### DIFF
--- a/source/swift.txt
+++ b/source/swift.txt
@@ -15,8 +15,8 @@ MongoDB Swift Driver
 Introduction
 ------------
 
-This is the official MongoDB Swift Driver. You can add the driver to your
-Swift app to communicate with MongoDB.
+This is the documentation for the official MongoDB Swift Driver. You can add
+the driver to your Swift app to communicate with MongoDB.
 
 .. tip::
 

--- a/source/swift.txt
+++ b/source/swift.txt
@@ -1,7 +1,5 @@
 .. _swift-language-center:
 
-.. include:: /includes/unicode-checkmark.rst
-
 ====================
 MongoDB Swift Driver
 ====================
@@ -17,7 +15,13 @@ MongoDB Swift Driver
 Introduction
 ------------
 
-This is the official MongoDB Swift Driver.
+This is the official MongoDB Swift Driver. You can add the driver to your
+Swift app to communicate with MongoDB.
+
+.. tip::
+
+   If you are looking for information about using Swift with MongoDB Realm,
+   see the :realm:`MongoDB Realm iOS SDK documentation </sdk/ios/>`.
 
 - `Usage Guide <https://github.com/mongodb/mongo-swift-driver#example-usage>`__
 


### PR DESCRIPTION
## Pull Request Info

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCS-14845

The new description is not especially engaging, but I created a ticket to update the text to something better across drivers: https://jira.mongodb.org/browse/DOCSP-19933

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=61a7f6555314b0809f8a9f8f

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/DOCS-14845-swift-driver-clarification/swift/

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?
