### PR TITLE
add checkmark for swift

### DIFF
--- a/source/swift.txt
+++ b/source/swift.txt
@@ -1,5 +1,7 @@
 .. _swift-language-center:
 
+.. include:: /includes/unicode-checkmark.rst
+
 ====================
 MongoDB Swift Driver
 ====================


### PR DESCRIPTION
## Pull Request Info

I noticed that the checkmarks for the swift page went away, and it was in the build logs. Compare [staging](https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/build-errors/swift/#compatibility) to [live](https://docs.mongodb.com/drivers/swift/#compatibility).

### Issue JIRA link:

N/A

### Snooty build log:

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=61b0d3045314b0809f841592

### Docs staging link (requires sign-in on MongoDB Corp SSO):

https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/build-errors/swift/#compatibility

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?
