### PR TITLE
Docs 14985

### DIFF
--- a/source/includes/language-compatibility-table-csharp.rst
+++ b/source/includes/language-compatibility-table-csharp.rst
@@ -223,7 +223,6 @@ through 4.8 only.
 .. [#atlas-connection] When using .NET 5/6, you can't connect to Atlas clusters running MongoDB 4.0 due to a certificate issue. This does not impact clusters running MongoDB 4.2+.
 
 .. [#2.14-note] .NET/C# driver version 2.14 requires .NET Framework 4.7.2 or higher.
-   and newer.
 
 .. [#4.5.2] .NET/C# driver versions 2.8 to 2.13 requires .NET Framework 4.5.2 or higher.
 

--- a/source/includes/mongodb-compatibility-table-rust.rst
+++ b/source/includes/mongodb-compatibility-table-rust.rst
@@ -12,7 +12,7 @@
      - MongoDB 4.0
      - MongoDB 3.6
 
-   * - 2.1 [#2.1-limitation]
+   * - 2.1 [#2.1-limitation]_
      -
      - |checkmark|
      - |checkmark|
@@ -21,7 +21,7 @@
      - |checkmark|
 
 
-   * - 2.0 [#limitations]
+   * - 2.0 [#limitations]_
      -
      - |checkmark|
      - |checkmark|
@@ -29,7 +29,7 @@
      - |checkmark|
      - |checkmark|
 
-   * - 1.1 [#limitations]
+   * - 1.1 [#limitations]_
      -
      -
      - |checkmark|
@@ -37,7 +37,7 @@
      - |checkmark|
      - |checkmark|
 
-   * - 1.0 [#limitations]
+   * - 1.0 [#limitations]_
      -
      -
      - |checkmark|
@@ -47,7 +47,7 @@
 
 The Rust driver is not compatible with MongoDB server versions older than 3.6.
 
-.. [#2.1-limitaiton] The Rust driver does not support :ref:`change streams <changeStreams>`.
+.. [#2.1-limitation] The Rust driver does not support :ref:`change streams <changeStreams>`.
 
 .. [#limitations] Not all features in MongoDB are available in these driver versions. Unsupported
    features include :ref:`Change Streams <changeStreams>`,

--- a/source/includes/mongodb-compatibility-table-rust.rst
+++ b/source/includes/mongodb-compatibility-table-rust.rst
@@ -1,7 +1,3 @@
-.. note::
-
-   The Rust driver is currently missing some features, which are noted below.
-   We plan to make this driver consistent with our other drivers in the future.
 
 .. list-table::
    :header-rows: 1
@@ -16,41 +12,44 @@
      - MongoDB 4.0
      - MongoDB 3.6
 
-   * - 2.1
+   * - 2.1 [#2.1-limitation]
      -
-     - |checkmark| (*)
-     - |checkmark| (*)
-     - |checkmark| (*)
-     - |checkmark| (*)
-     - |checkmark| (*)
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
 
 
-   * - 2.0
+   * - 2.0 [#limitations]
      -
-     - |checkmark| (*)
-     - |checkmark| (*)
-     - |checkmark| (*)
-     - |checkmark| (*)
-     - |checkmark| (*)
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
 
-   * - 1.1
+   * - 1.1 [#limitations]
      -
      -
-     - |checkmark| (*)
-     - |checkmark| (*)
-     - |checkmark| (*)
-     - |checkmark| (*)
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
 
-   * - 1.0
+   * - 1.0 [#limitations]
      -
      -
-     - |checkmark| (*)
-     - |checkmark| (*)
-     - |checkmark| (*)
-     - |checkmark| (*)
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
 
 The Rust driver is not compatible with MongoDB server versions older than 3.6.
 
-.. info::
+.. [#2.1-limitaiton] The Rust driver does not support :ref:`change streams <changeStreams>`.
 
-   The Rust driver does not currently support :ref:`Change Streams <changeStreams>`.
+.. [#limitations] Not all features in MongoDB are available in these driver versions. Unsupported
+   features include :ref:`Change Streams <changeStreams>`,
+   :manual:`Causal Consistency </core/causal-consistency-read-write-concerns>`, and
+   :atlas:`Serverless Instance </reference/serverless-instance-limitations>` support.

--- a/source/includes/mongodb-compatibility-table-rust.rst
+++ b/source/includes/mongodb-compatibility-table-rust.rst
@@ -16,6 +16,15 @@
      - MongoDB 4.0
      - MongoDB 3.6
 
+   * - 2.1
+     -
+     - |checkmark| (*)
+     - |checkmark| (*)
+     - |checkmark| (*)
+     - |checkmark| (*)
+     - |checkmark| (*)
+
+
    * - 2.0
      -
      - |checkmark| (*)
@@ -42,7 +51,6 @@
 
 The Rust driver is not compatible with MongoDB server versions older than 3.6.
 
-(*) Not all features in MongoDB are available in this version of the
-driver. Unsupported features include :ref:`Change Streams <changeStreams>`,
-:manual:`Causal Consistency </core/causal-consistency-read-write-concerns>`, and
-:atlas:`Serverless Instance </reference/serverless-instance-limitations>` support.
+.. info::
+
+   The Rust driver does not currently support :ref:`Change Streams <changeStreams>`.

--- a/source/rust.txt
+++ b/source/rust.txt
@@ -118,8 +118,6 @@ corresponding connection code samples.
 Connect to a MongoDB Server on Your Local Machine
 -------------------------------------------------
 
-.. include:: /includes/localhost-connection.rst
-
 To test whether you can connect to your server, replace the connection
 string in the :ref:`Connect to MongoDB Atlas <connect-atlas-rust-driver>` code
 example and run it.


### PR DESCRIPTION
## Pull Request Info
This corrects a typo I found on the C# language compatibility page, and updates the Rust page and compatibility.

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCS-14985

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=61b9093fc52f2a460f96e8cd

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/DOCS-14985/rust/#compatibility

### Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?
