### PR TITLE
DOCSP-20087: Do not list ext-1.12 and lib-1.11 as compatible with MongoDB 5.1

### DIFF
--- a/source/includes/mongodb-compatibility-table-php.rst
+++ b/source/includes/mongodb-compatibility-table-php.rst
@@ -16,7 +16,7 @@
      - MongoDB 2.6
 
    * - ext 1.12 + lib 1.11
-     - |checkmark|
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|


### PR DESCRIPTION
## Pull Request Info

MongoDB 5.1 compatibility was previously added for this ext/lib version in https://github.com/mongodb/docs-ecosystem/commit/a423932862cc52a3890e92014f97b5de0dc83edf; however, the actual extension release is tied to libmongoc 1.20. Although that release includes KMIP support for CSFLE, full support for MongoDB 5.1 will not come until libmongoc 1.21 (tentatively PHP ext-1.13 and lib-1.12).

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-20087