### PR TITLE
(DOCSP-19933) Improve and standardize intro text for drivers

### DIFF
--- a/source/c.txt
+++ b/source/c.txt
@@ -17,7 +17,11 @@ MongoDB C Driver
 Introduction
 ------------
 
-Welcome to the documentation site for the official MongoDB C Driver. You can add the driver to your application to work with MongoDB in C. Download the required libraries, ``libmongoc`` and ``libbson``,  from `mongoc.org <http://mongoc.org/libmongoc/current/installing.html>`__ or set up a runnable project by following our tutorial.
+Welcome to the documentation site for the official MongoDB C Driver. 
+You can add the driver to your application to work with MongoDB in C. 
+Download the required libraries, ``libmongoc`` and ``libbson``,  from 
+`mongoc.org <http://mongoc.org/libmongoc/current/installing.html>`__ or 
+set up a runnable project by following our tutorial.
 
 - `Tutorial <http://mongoc.org/libmongoc/current/tutorial.html>`__
 

--- a/source/c.txt
+++ b/source/c.txt
@@ -17,7 +17,7 @@ MongoDB C Driver
 Introduction
 ------------
 
-Welcome to the documentation site for the official MongoDB C Driver. 
+Welcome to the documentation site for the official MongoDB C driver. 
 You can add the driver to your application to work with MongoDB in C. 
 Download the required libraries, ``libmongoc`` and ``libbson``,  from 
 `mongoc.org <http://mongoc.org/libmongoc/current/installing.html>`__ or 

--- a/source/c.txt
+++ b/source/c.txt
@@ -20,8 +20,8 @@ Introduction
 Welcome to the documentation site for the official MongoDB C driver. 
 You can add the driver to your application to work with MongoDB in C. 
 Download the required libraries, ``libmongoc`` and ``libbson``,  from 
-`mongoc.org <http://mongoc.org/libmongoc/current/installing.html>`__ or 
-set up a runnable project by following our tutorial.
+`mongoc.org <https://mongoc.org/libmongoc/current/installing.html>`__ 
+or set up a runnable project by following our tutorial.
 
 - `Tutorial <http://mongoc.org/libmongoc/current/tutorial.html>`__
 

--- a/source/c.txt
+++ b/source/c.txt
@@ -17,12 +17,7 @@ MongoDB C Driver
 Introduction
 ------------
 
-The MongoDB C Driver, also known as “libmongoc”, is the official client library
-for C applications, and provides a base for MongoDB drivers in higher-level
-languages.
-
-The library is compatible with all major platforms. It depends on libbson
-to create and parse BSON data.
+Welcome to the documentation site for the official MongoDB C Driver. You can add the driver to your application to work with MongoDB in C. Download the required libraries, ``libmongoc`` and ``libbson``,  from `mongoc.org <http://mongoc.org/libmongoc/current/installing.html>`__ or set up a runnable project by following our tutorial.
 
 - `Tutorial <http://mongoc.org/libmongoc/current/tutorial.html>`__
 

--- a/source/csharp.txt
+++ b/source/csharp.txt
@@ -17,7 +17,7 @@ MongoDB C#/.NET Driver
 Introduction
 ------------
 
-TWelcome to the documentation site for the official MongoDB C#/.NET 
+Welcome to the documentation site for the official MongoDB C#/.NET 
 driver. You can add the driver to your application to work with MongoDB 
 in C#/.NET. Download it using `NuGet <https://www.nuget.org/>`__ or 
 set up a runnable project by following our Getting Started guide.

--- a/source/csharp.txt
+++ b/source/csharp.txt
@@ -17,8 +17,10 @@ MongoDB C#/.NET Driver
 Introduction
 ------------
 
-The official MongoDB C#/.NET Driver provides asynchronous interaction
-with MongoDB.
+TWelcome to the documentation site for the official MongoDB C#/.NET 
+driver. You can add the driver to your application to work with MongoDB 
+in C#/.NET. Download it using `NuGet <https://www.nuget.org/>`__ or 
+set up a runnable project by following our Getting Started guide.
 
 - `Getting Started <{+csharp-docs-versioned+}/getting_started/>`__
 

--- a/source/cxx.txt
+++ b/source/cxx.txt
@@ -17,8 +17,11 @@ MongoDB C++ Driver
 Introduction
 ------------
 
-The MongoDB C++ Driver is the official client library for C++ applications
-using the C++11 (or later) standard.
+Welcome to the documentation site for the official MongoDB C driver. 
+You can add the driver to your application to work with MongoDB using 
+the C++11 (or later) standard. Download the library, ``mongocxx``,  
+from `mongocxx.org <http://mongocxx.org/mongocxx-v3/installation/>`__ 
+or set up a runnable project by following our tutorial.
 
 - `Tutorial <http://mongocxx.org/mongocxx-v3/tutorial/>`__
 

--- a/source/cxx.txt
+++ b/source/cxx.txt
@@ -17,7 +17,7 @@ MongoDB C++ Driver
 Introduction
 ------------
 
-Welcome to the documentation site for the official MongoDB C driver. 
+Welcome to the documentation site for the official MongoDB C++ driver. 
 You can add the driver to your application to work with MongoDB using 
 the C++11 or later standard. Download the library, ``mongocxx``,  
 from `mongocxx.org <http://mongocxx.org/mongocxx-v3/installation/>`__ 

--- a/source/cxx.txt
+++ b/source/cxx.txt
@@ -19,7 +19,7 @@ Introduction
 
 Welcome to the documentation site for the official MongoDB C driver. 
 You can add the driver to your application to work with MongoDB using 
-the C++11 (or later) standard. Download the library, ``mongocxx``,  
+the C++11 or later standard. Download the library, ``mongocxx``,  
 from `mongocxx.org <http://mongocxx.org/mongocxx-v3/installation/>`__ 
 or set up a runnable project by following our tutorial.
 

--- a/source/java-drivers.txt
+++ b/source/java-drivers.txt
@@ -20,11 +20,16 @@ Java MongoDB Drivers
 Introduction
 ------------
 
-`Java Driver <https://docs.mongodb.com/drivers/java/sync/current>`__ is the recommended MongoDB Java Driver.
+Welcome to the documentation site for the official MongoDB Java 
+drivers. You can add one of the following drivers to your application 
+to work with MongoDB in Java:
 
-For asynchronous stream processing and reactive streams interoperability,
-the :doc:`Reactive Streams Driver </reactive-streams>` is the
-recommended MongoDB Java Driver.
+- Use the 
+  `Java Driver <https://docs.mongodb.com/drivers/java/sync/current>`__ 
+  for synchronous Java applications.
+  
+- Use the :doc:`Reactive Streams Driver </reactive-streams>` for 
+  asynchronous stream processing and reactive streams interoperability.
 
 Take the free online course taught by MongoDB
 ---------------------------------------------

--- a/source/java-drivers.txt
+++ b/source/java-drivers.txt
@@ -28,8 +28,8 @@ to work with MongoDB in Java:
   `Java Driver <https://docs.mongodb.com/drivers/java/sync/current>`__ 
   for synchronous Java applications.
   
-- Use the :doc:`Reactive Streams Driver </reactive-streams>` for 
-  asynchronous stream processing and reactive streams interoperability.
+- Use the :doc:`Reactive Streams Driver </reactive-streams>` to use the 
+  Reactive Streams API for asynchronous stream processing.
 
 Take the free online course taught by MongoDB
 ---------------------------------------------

--- a/source/java.txt
+++ b/source/java.txt
@@ -11,8 +11,6 @@ Java MongoDB Drivers
    :backlinks: none
    :depth: 1
 
-.. This page may be an unused duplicate of java-drivers.
-
 Introduction
 ------------
 

--- a/source/java.txt
+++ b/source/java.txt
@@ -11,6 +11,8 @@ Java MongoDB Drivers
    :backlinks: none
    :depth: 1
 
+.. This page may be an unused duplicate of java-drivers.
+
 Introduction
 ------------
 

--- a/source/motor.txt
+++ b/source/motor.txt
@@ -17,15 +17,16 @@ Motor (Async Driver)
 Introduction
 ------------
 
-**Motor** is the recommended asynchronous Python driver for MongoDB.
-It is compatible with `Tornado <http://www.tornadoweb.org/>`__ and
-`asyncio <https://docs.python.org/3/library/asyncio.html>`__. We recommend
-that you use this driver if you need to run asynchronous operations. If
-you do not need to access MongoDB in a non-blocking manner or from
-co-routines, we recommend that you use the :doc:`PyMongo </pymongo>`
-driver instead.
+You can use Motor, the official MongoDB driver for asynchronous Python 
+applications, to interact with MongoDB. Download it using 
+`pip <http://pypi.python.org/pypi/pip>`__
+or set up a runnable project by following our tutorials.
 
-Follow the links below to learn more about how to use the Motor driver:
+.. tip::
+
+   If you do not need to access MongoDB in a non-blocking manner or from
+   co-routines, we recommend that you use the :doc:`PyMongo </pymongo>`
+   driver instead.
 
 - `Tutorial on using Motor with Tornado <http://motor.readthedocs.org/en/stable/tutorial-tornado.html>`__
 

--- a/source/motor.txt
+++ b/source/motor.txt
@@ -17,9 +17,9 @@ Motor (Async Driver)
 Introduction
 ------------
 
-You can use Motor, the official MongoDB driver for asynchronous Python 
-applications, to interact with MongoDB. Download it using 
-`pip <http://pypi.python.org/pypi/pip>`__
+Welcome to the documentation site for Motor, the official MongoDB 
+driver for asynchronous Python applications. Download it using 
+`pip <https://pypi.python.org/pypi/pip>`__
 or set up a runnable project by following our tutorials.
 
 .. tip::

--- a/source/php.txt
+++ b/source/php.txt
@@ -23,15 +23,23 @@ MongoDB PHP Driver
 Introduction
 ------------
 
-The PHP driver consists of two components, the MongoDB `extension <https://github.com/mongodb/mongo-php-driver>`_
-and `library <https://docs.mongodb.com/php-library/current>`_.
+Welcome to the documentation site for the official MongoDB PHP driver. 
+You can add the driver to your application to work with MongoDB in PHP. 
+The MongoDB PHP Driver consists of the two following components:
 
-The extension provides a low-level API and mainly serves to integrate
-`libmongoc and libbson <https://docs.mongodb.com/drivers/c/>`_ with PHP.
+- The `extension <https://github.com/mongodb/mongo-php-driver>`_, which 
+  provides a low-level API and mainly serves to integrate 
+  `libmongoc and libbson <https://docs.mongodb.com/drivers/c/>`_ with 
+  PHP.
 
-While it is possible to use the extension alone, users are strongly encouraged
-to use the extension and library together. The library provides a high-level API
-consistent with other MongoDB language drivers.
+- The `library <https://docs.mongodb.com/php-library/current>`_, which 
+  provides a high-level API for working with MongoDB 
+  databases consistent with other MongoDB language drivers.
+
+While it is possible to use the extension alone, MongoDB recommends 
+using both the extension and the library together. Download the 
+components you need or set up a runnable project by following our 
+tutorials.
 
 - `Tutorials <https://docs.mongodb.com/php-library/current/tutorial>`__
 

--- a/source/pymongo.txt
+++ b/source/pymongo.txt
@@ -15,9 +15,9 @@ PyMongo
 Introduction
 ------------
 
-You can use PyMongo, the official MongoDB driver for synchronous Python 
-applications, to interact with MongoDB. Download it using 
-`pip <http://pypi.python.org/pypi/pip>`__
+Welcome to the documentation site for PyMongo, the official MongoDB 
+driver for synchronous Python applications. Download it using 
+`pip <https://pypi.python.org/pypi/pip>`__
 or set up a runnable project by following our tutorial.
 
 .. tip::

--- a/source/pymongo.txt
+++ b/source/pymongo.txt
@@ -15,15 +15,19 @@ PyMongo
 Introduction
 ------------
 
-**PyMongo** is the official MongoDB Python driver for MongoDB. We
-recommend you use this driver to work with MongoDB from Python. If you
-need to access MongoDB in a non-blocking manner or from co-routines, we
-recommend that you use the :doc:`Motor </motor>` driver instead.
+You can use PyMongo, the official MongoDB driver for synchronous Python 
+applications, to interact with MongoDB. Download it using 
+`pip <http://pypi.python.org/pypi/pip>`__
+or set up a runnable project by following our tutorials.
 
-Follow the links below to learn more about how to use the PyMongo driver:
+.. tip::
 
-- `Tutorial <https://pymongo.readthedocs.io/en/stable/tutorial.html>`__ on
-  how to connect to MongoDB and run common operations.
+   If you need to access MongoDB in a non-blocking manner or from 
+   co-routines, we recommend that you use the :doc:`Motor </motor>` 
+   driver instead.
+
+- `Tutorial <https://pymongo.readthedocs.io/en/stable/tutorial.html>`__ 
+  on how to connect to MongoDB and run common operations.
 
 - `API Reference <https://pymongo.readthedocs.io/en/stable/api/index.html>`__
 

--- a/source/pymongo.txt
+++ b/source/pymongo.txt
@@ -18,7 +18,7 @@ Introduction
 You can use PyMongo, the official MongoDB driver for synchronous Python 
 applications, to interact with MongoDB. Download it using 
 `pip <http://pypi.python.org/pypi/pip>`__
-or set up a runnable project by following our tutorials.
+or set up a runnable project by following our tutorial.
 
 .. tip::
 

--- a/source/pymongo.txt
+++ b/source/pymongo.txt
@@ -40,12 +40,12 @@ or set up a runnable project by following our tutorial.
 Installation
 ------------
 
-You must install the PyMongo driver module to make it available to your Python
-application. We recommend using `pip <http://pypi.python.org/pypi/pip>`__
-to install PyMongo.
+You must install the PyMongo driver module to make it available to your 
+Python application. We recommend using 
+`pip <http://pypi.python.org/pypi/pip>`__ to install PyMongo.
 
-The following command demonstrates how you can install the latest version of
-the module using the command line:
+The following command demonstrates how you can install the latest 
+version of the module using the command line:
 
 .. code-block:: sh
 

--- a/source/python.txt
+++ b/source/python.txt
@@ -23,14 +23,12 @@ MongoDB Python Drivers
 Introduction
 ------------
 
-You can access MongoDB from your Python application using one of our
-official MongoDB Python drivers. Follow the links below to get started
-with each driver:
+Welcome to the documentation site for the official MongoDB Python 
+drivers. You can add one of the following drivers to your application 
+to work with MongoDB in Python:
 
-- :doc:`PyMongo </pymongo>` is the recommended driver to work with MongoDB
-  using Python.
-- :doc:`Motor </motor>` is the recommended driver for when you need
-  non-blocking access to MongoDB using Python.
+- Use :doc:`PyMongo </pymongo>` for synchronous Python applications.
+
+- Use :doc:`Motor </motor>` for asynchronous Python applications.
 
 .. include:: /includes/university-m220p.rst
-

--- a/source/reactive-streams.txt
+++ b/source/reactive-streams.txt
@@ -15,8 +15,11 @@ MongoDB Java Reactive Streams
 Introduction
 ------------
 
-**Java Reactive Streams** is an official Java driver for MongoDB and is the
-recommended driver for working with reactive streams in the JVM ecosystem.
+You can use the Reactive Streams Driver, the official MongoDB driver 
+for asynchronous Java applications, to interact with MongoDB. Download 
+it by following the 
+:java-docs:`Installation Guide <driver-reactive/getting-started/installation/>` 
+or set up a runnable project by following our tutorials.
 
 - :java-docs:`Reference Documentation <driver-reactive/>`
 

--- a/source/reactive-streams.txt
+++ b/source/reactive-streams.txt
@@ -15,8 +15,8 @@ MongoDB Java Reactive Streams
 Introduction
 ------------
 
-You can use the Reactive Streams Driver, the official MongoDB driver 
-for asynchronous Java applications, to interact with MongoDB. Download 
+Welcome to the documentation site for the Reactive Streams Driver, the 
+official MongoDB driver for asynchronous Java applications. Download 
 it by following the 
 :java-docs:`Installation Guide <driver-reactive/getting-started/installation/>` 
 or set up a runnable project by following our tutorials.

--- a/source/rust.txt
+++ b/source/rust.txt
@@ -17,7 +17,10 @@ MongoDB Rust Driver
 Introduction
 ------------
 
-This is the official MongoDB Rust Driver.
+Welcome to the documentation site for the official MongoDB Rust driver. 
+You can add the driver to your application to work with MongoDB in 
+Rust. Download it from `crates.io <https://crates.io/crates/mongodb>`__ 
+or set up a runnable project with examples from our Usage Guide.
 
 - `Usage Guide <https://github.com/mongodb/mongo-rust-driver#example-usage>`__
 

--- a/source/scala.txt
+++ b/source/scala.txt
@@ -17,10 +17,10 @@ MongoDB Scala Driver
 Introduction
 ------------
 
-This is the officially supported Scala driver for MongoDB.
-
-It's a modern idiomatic Scala driver with asynchronous and non-blocking IO.
-
+Welcome to the documentation site for the official MongoDB Scala 
+driver. You can add the driver to your application to work 
+asynchronously with MongoDB in Scala. Download it using ``sbt`` or 
+``maven``, or set up a runnable project by following our tutorials.
 
 - :java-docs:`Reference Documentation <driver-scala/>`
 

--- a/source/scala.txt
+++ b/source/scala.txt
@@ -19,8 +19,10 @@ Introduction
 
 Welcome to the documentation site for the official MongoDB Scala 
 driver. You can add the driver to your application to work 
-asynchronously with MongoDB in Scala. Download it using ``sbt`` or 
-``maven``, or set up a runnable project by following our tutorials.
+asynchronously with MongoDB in Scala. Download it using 
+`sbt <https://www.scala-sbt.org/>`__ or 
+`Apache Maven <https://maven.apache.org/>`__, or set up a runnable 
+project by following our tutorials.
 
 - :java-docs:`Reference Documentation <driver-scala/>`
 

--- a/source/swift.txt
+++ b/source/swift.txt
@@ -17,8 +17,11 @@ MongoDB Swift Driver
 Introduction
 ------------
 
-This is the documentation for the official MongoDB Swift Driver. You can add
-the driver to your Swift app to communicate with MongoDB.
+Welcome to the documentation site for the official MongoDB Swift 
+driver. You can add the driver to your application to work with MongoDB 
+in Swift. Download it with the 
+`Swift Package Manager <https://www.swift.org/package-manager/>`__ or 
+set up a runnable project with examples from our Usage Guide.
 
 .. tip::
 


### PR DESCRIPTION
## Pull Request Info

[Planning document](https://docs.google.com/document/d/1hWScrmE6EVK22WN0ATcVb29emFT_uzdsyosonm7_7Co/edit#)

This PR updates the intros for the following drivers, all within the docs-ecosystem repo:

- [C Driver </c>](https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/DOCSP-19933/c/)
- [C++ Driver </cxx>](https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/DOCSP-19933/cxx/)
- [C# and .NET Driver </csharp>](https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/DOCSP-19933/csharp/)
- [Java Drivers parent page </java-drivers>](https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/DOCSP-19933/java-drivers/)
   - Reactive Streams Driver </reactive-streams>
- [PHP Driver </php>](https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/DOCSP-19933/php/)
- [Python Drivers </python>](https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/DOCSP-19933/python/)
  - PyMongo
  - Motor 
- [Rust Driver </rust>](https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/DOCSP-19933/rust/)
- [Scala Driver </scala>](https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/DOCSP-19933/scala/)
- [Swift Driver </swift>](https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/DOCSP-19933/swift/)

The following drivers will be updated from their own repos in additional PRs:

- Go Driver
- Node.js Driver
- Ruby Driver
- _Java Sync_ Java Driver
- [PHP Library](https://github.com/mongodb/docs-php-library)

The intro is a template, adjusted for each driver. I'll apply any feedback about standardized language throughout the drivers. 

### Open Questions
- Should the "how/where to download" part of the intro just link to the Install section? Every landing page has an Install section so the intro would be more uniform that way. 

### Issue JIRA link:
https://jira.mongodb.org/browse/DOCSP-19933

### Snooty build log:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=61e83c44bcf82347e58119e7

The errors should be fixed with https://github.com/mongodb/docs-java/pull/196/files#diff-6ec1d7a2a8415a0935fed8cfb7583531bbbbbc883422584c97a61f7f8cace9d3L1

### Docs staging link (requires sign-in on MongoDB Corp SSO):
https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/DOCSP-19933/

### Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Does it render on staging correctly?
- [x] Are all the links working?
- [x] Are the staging and workerpool job links in the PR description updated?
