### PR TITLE
update redirects for cpp

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -26,12 +26,12 @@ raw: docs/drivers/downloads -> ${base}/
 raw: docs/drivers/syntax-table -> ${base}/
 
 # cpp
-raw: docs/drivers/tutorial/download-and-compile-cpp-driver -> https://github.com/mongodb/mongo-cxx-driver/wiki/Download%20and%20Compile
-raw: docs/drivers/tutorial/getting-started-with-cpp-driver -> https://github.com/mongodb/mongo-cxx-driver/wiki/blob/legacy/README.md
-raw: docs/drivers/cpp-bson-array-examples -> https://github.com/mongodb/mongo-cxx-driver/wiki/blob/legacy/src/mongo/client/examples/arrayExample.cpp
-raw: docs/drivers/cpp-bson-helper-functions -> https://github.com/mongodb/mongo-cxx-driver/wiki/BSON%20Helper%20Functions
-raw: docs/drivers/cpp-to-sql-to-mongo-shell -> https://github.com/mongodb/mongo-cxx-driver/wiki
-raw: docs/drivers/tutorial/download-and-compile-cpp-driver-legacy -> https://github.com/mongodb/mongo-cxx-driver/wiki/Download-and-Compile-the-Legacy-Driver
+raw: docs/drivers/tutorial/download-and-compile-cpp-driver -> http://mongocxx.org/mongocxx-v3/installation/
+raw: docs/drivers/tutorial/getting-started-with-cpp-driver -> http://mongocxx.org/mongocxx-v3/tutorial/
+raw: docs/drivers/cpp-bson-array-examples -> http://mongocxx.org/mongocxx-v3/working-with-bson/
+raw: docs/drivers/cpp-bson-helper-functions ->http://mongocxx.org/mongocxx-v3/working-with-bson/
+raw: docs/drivers/cpp-to-sql-to-mongo-shell -> http://mongocxx.org
+raw: docs/drivers/tutorial/download-and-compile-cpp-driver-legacy ->http://mongocxx.org/mongocxx-v3/installation/
 raw: docs/drivers/tutorial/authenticate-with-cpp-driver -> http://mongocxx.org/
 
 # csharp


### PR DESCRIPTION
## Pull Request Info

Updating cpp redirects to point to the doc site rather than the github wiki.

[PR Reviewing Guidelines](https://github.com/mongodb/docs-ecosystem/blob/master/REVIEWING.md)

### Issue JIRA link:
N/A

### Snooty build log:


### Docs staging link (requires sign-in on MongoDB Corp SSO):

### Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Does it render on staging correctly?
- [ ] Are all the links working?
- [ ] Are the staging and workerpool job links in the PR description updated?

### If your page documents a concept, does it meet the following criteria?

- [ ] Target the [Jasmin persona](https://drive.google.com/file/d/14FbBOLCVxwSP6M9BK4Nz1Ir9tzxT8_02/view)
- [ ] Target the [Lucas persona](https://drive.google.com/file/d/1J2vqJxo7ldv7OP_obA9Q-avf0o_ju4Lk/view)
