### PR TITLE
add link to rust driver manual

### DIFF
--- a/source/rust.txt
+++ b/source/rust.txt
@@ -22,7 +22,7 @@ You can add the driver to your application to work with MongoDB in
 Rust. Download it from `crates.io <https://crates.io/crates/mongodb>`__
 or set up a runnable project with examples from our Usage Guide.
 
-- `Usage Guide <https://github.com/mongodb/mongo-rust-driver#example-usage>`__
+- `The Rust Driver Manual <https://mongodb.github.io/mongo-rust-driver/manual/>`__
 
 - `API Reference <https://docs.rs/mongodb/latest>`__
 
@@ -30,7 +30,6 @@ or set up a runnable project with examples from our Usage Guide.
 
 - `Source Code <https://github.com/mongodb/mongo-rust-driver/>`__
 
-- `The Rust Driver Manual <https://mongodb.github.io/mongo-rust-driver/manual/>`__
 
 
 Installation

--- a/source/rust.txt
+++ b/source/rust.txt
@@ -30,6 +30,8 @@ or set up a runnable project with examples from our Usage Guide.
 
 - `Source Code <https://github.com/mongodb/mongo-rust-driver/>`__
 
+- `The Rust Driver Manual <https://mongodb.github.io/mongo-rust-driver/manual/>`__
+
 
 Installation
 ------------


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-ecosystem/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-22034>
Staging - https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/DOCSP-22034/rust/

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Are all the links working?
