### PR TITLE
DOCSP-22076: CSFLE redirects

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -10,12 +10,13 @@ raw: docs/drivers/go -> https://www.mongodb.com/docs/drivers/go/current/
 # Java
 raw: docs/drivers/java -> ${base}/java-drivers/
 
-
-# FLE https://jira.mongodb.org/browse/DOP-1633
-raw: docs/drivers/use-cases/client-side-field-level-encryption-guide -> ${base}/security/client-side-field-level-encryption-guide/
-raw: docs/drivers/use-cases/client-side-field-level-encryption-local-key-to-kms -> ${base}/security/client-side-field-level-encryption-local-key-to-kms/
-raw: docs/drivers/use-cases/sensitive-data-encryption ->  ${base}/security/client-side-field-level-encryption-guide/
-
+# Manual FLE merge - update URLs after 6.0 release
+raw: docs/drivers/security -> https://mongodb.com/docs/v6.0/core/security-client-side-encryption/
+raw: docs/drivers/security/client-side-field-level-encryption-guide -> https://mongodb.com/docs/v6.0/core/security-client-side-encryption/
+raw: docs/drivers/security/client-side-field-level-encryption-local-key-to-kms -> https://mongodb.com/docs/v6.0/core/security-client-side-encryption/
+raw: docs/drivers/use-cases/client-side-field-level-encryption-guide -> https://mongodb.com/docs/v6.0/core/security-client-side-encryption/
+raw: docs/drivers/use-cases/client-side-field-level-encryption-local-key-to-kms -> https://mongodb.com/docs/v6.0/core/security-client-side-encryption/
+raw: docs/drivers/use-cases/sensitive-data-encryption -> https://mongodb.com/docs/v6.0/core/security-client-side-encryption/
 
 ###
 ### Redirects for Legacy Drivers Content

--- a/source/includes/mongodb-compatibility-table-rust.rst
+++ b/source/includes/mongodb-compatibility-table-rust.rst
@@ -23,28 +23,28 @@
      - ✓
      - ✓
    * - 2.1 [#2.1-limitation]_
-     - 
-     - 
-     - 
+     -
+     -
+     -
      - ✓
      - ✓
      - ✓
      - ✓
      - ✓
    * - 2.0 [#limitations]_
-     - 
-     - 
-     - 
+     -
+     -
+     -
      - ✓
      - ✓
      - ✓
      - ✓
      - ✓
    * - 1.1 [#limitations]_
-     - 
-     - 
-     - 
-     - 
+     -
+     -
+     -
+     -
      - ✓
      - ✓
      - ✓
@@ -52,22 +52,22 @@
 
 The Rust driver is not compatible with MongoDB server versions older than 3.6.
 
-.. [#2.2-limitation] The Rust driver does not support Decimal128, 
-   :ref:`Client-Side Field Level Encryption <ecosystem-csfle>`, 
+.. [#2.2-limitation] The Rust driver does not support Decimal128,
+   :ref:`Client-Side Field Level Encryption <manual-csfle-feature>`,
    :manual:`GridFS </core/gridfs/>`, and
    :manual:`OCSP </core/security-transport-encryption/>`.
 
-.. [#2.1-limitation] The Rust driver does not support Decimal128, 
-   :ref:`Client-Side Field Level Encryption <ecosystem-csfle>`, 
-   :manual:`GridFS </core/gridfs/>`, 
-   :manual:`OCSP </core/security-transport-encryption/>`, 
+.. [#2.1-limitation] The Rust driver does not support Decimal128,
+   :ref:`Client-Side Field Level Encryption <manual-csfle-feature>`,
+   :manual:`GridFS </core/gridfs/>`,
+   :manual:`OCSP </core/security-transport-encryption/>`,
    and :ref:`change streams <changeStreams>`.
 
 .. [#limitations] Not all features in MongoDB are available in these driver versions. Unsupported
-   features include Decimal128, 
-   :ref:`Client-Side Field Level Encryption <ecosystem-csfle>`, 
-   :manual:`GridFS </core/gridfs/>`, 
-   :manual:`OCSP </core/security-transport-encryption/>`, 
+   features include Decimal128,
+   :ref:`Client-Side Field Level Encryption <manual-csfle-feature>`,
+   :manual:`GridFS </core/gridfs/>`,
+   :manual:`OCSP </core/security-transport-encryption/>`,
    :ref:`change streams <changeStreams>`,
    :manual:`Causal Consistency </core/causal-consistency-read-write-concerns>`, and
    :atlas:`Serverless Instances </reference/serverless-instance-limitations>`.

--- a/source/includes/mongodb-compatibility-table-rust.rst
+++ b/source/includes/mongodb-compatibility-table-rust.rst
@@ -53,19 +53,19 @@
 The Rust driver is not compatible with MongoDB server versions older than 3.6.
 
 .. [#2.2-limitation] The Rust driver does not support Decimal128,
-   :ref:`Client-Side Field Level Encryption <manual-csfle-feature>`,
+   :ref:`Client-Side Field Level Encryption <ecosystem-csfle>`,
    :manual:`GridFS </core/gridfs/>`, and
    :manual:`OCSP </core/security-transport-encryption/>`.
 
 .. [#2.1-limitation] The Rust driver does not support Decimal128,
-   :ref:`Client-Side Field Level Encryption <manual-csfle-feature>`,
+   :ref:`Client-Side Field Level Encryption <ecosystem-csfle>`,
    :manual:`GridFS </core/gridfs/>`,
    :manual:`OCSP </core/security-transport-encryption/>`,
    and :ref:`change streams <changeStreams>`.
 
 .. [#limitations] Not all features in MongoDB are available in these driver versions. Unsupported
    features include Decimal128,
-   :ref:`Client-Side Field Level Encryption <manual-csfle-feature>`,
+   :ref:`Client-Side Field Level Encryption <ecosystem-csfle>`,
    :manual:`GridFS </core/gridfs/>`,
    :manual:`OCSP </core/security-transport-encryption/>`,
    :ref:`change streams <changeStreams>`,

--- a/source/includes/mongodb-compatibility-table-swift.rst
+++ b/source/includes/mongodb-compatibility-table-swift.rst
@@ -24,8 +24,8 @@
      - |checkmark|
 
    * - 1.2.0 [#1.2-1.3-limitations]_
-     - 
-     - 
+     -
+     -
      -
      - |checkmark|
      - |checkmark|
@@ -34,8 +34,8 @@
      - |checkmark|
 
    * - 1.1.0 [#1.0-1.1-limitations]_
-     - 
-     - 
+     -
+     -
      -
      -
      - |checkmark|
@@ -44,8 +44,8 @@
      - |checkmark|
 
    * - 1.0.0 [#1.0-1.1-limitations]_
-     - 
-     - 
+     -
+     -
      -
      -
      - |checkmark|
@@ -56,10 +56,10 @@
 The Swift driver is not compatible with MongoDB server versions older than 3.6.
 
 .. [#1.2-1.3-limitations] Versions 1.2 and 1.3 do not include support for
-   :ref:`Client-Side Field Level Encryption <ecosystem-csfle>`,
+   :ref:`Client-Side Field Level Encryption <manual-csfle-feature>`,
    :manual:`GridFS </core/gridfs/>`, and authentication using AWS IAM roles.
 
 .. [#1.0-1.1-limitations] Versions 1.0 and 1.1 do not include support for
-   :manual:`OCSP </core/security-transport-encryption/>`, 
-   :ref:`Client-Side Field Level Encryption <ecosystem-csfle>`,
+   :manual:`OCSP </core/security-transport-encryption/>`,
+   :ref:`Client-Side Field Level Encryption <manual-csfle-feature>`,
    :manual:`GridFS </core/gridfs/>`, and authentication using AWS IAM roles.

--- a/source/includes/mongodb-compatibility-table-swift.rst
+++ b/source/includes/mongodb-compatibility-table-swift.rst
@@ -56,10 +56,10 @@
 The Swift driver is not compatible with MongoDB server versions older than 3.6.
 
 .. [#1.2-1.3-limitations] Versions 1.2 and 1.3 do not include support for
-   :ref:`Client-Side Field Level Encryption <manual-csfle-feature>`,
+   :ref:`Client-Side Field Level Encryption <ecosystem-csfle>`,
    :manual:`GridFS </core/gridfs/>`, and authentication using AWS IAM roles.
 
 .. [#1.0-1.1-limitations] Versions 1.0 and 1.1 do not include support for
    :manual:`OCSP </core/security-transport-encryption/>`,
-   :ref:`Client-Side Field Level Encryption <manual-csfle-feature>`,
+   :ref:`Client-Side Field Level Encryption <ecosystem-csfle>`,
    :manual:`GridFS </core/gridfs/>`, and authentication using AWS IAM roles.

--- a/source/index.txt
+++ b/source/index.txt
@@ -8,7 +8,7 @@
 Start Developing with MongoDB
 =============================
 
-Connect your application to your database with one of our official libraries.
+Connect your application to your database with one of our official drivers.
 
 The following libraries are officially supported by MongoDB. They are actively maintained, support new MongoDB features, and receive bug fixes, performance enhancements, and security patches.
 
@@ -32,4 +32,3 @@ Don’t see your desired language? Browse a list of :doc:`community supported li
    Scala Driver </scala>
    Swift Driver </swift>
    About Compatibility Tables <about-compatibility>
-   Security </security>

--- a/source/index.txt
+++ b/source/index.txt
@@ -8,7 +8,7 @@
 Start Developing with MongoDB
 =============================
 
-Connect your application to your database with one of our official drivers.
+Connect your application to your database with one of our official libraries.
 
 The following libraries are officially supported by MongoDB. They are actively maintained, support new MongoDB features, and receive bug fixes, performance enhancements, and security patches.
 
@@ -32,3 +32,4 @@ Don’t see your desired language? Browse a list of :doc:`community supported li
    Scala Driver </scala>
    Swift Driver </swift>
    About Compatibility Tables <about-compatibility>
+   Security </security>


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-ecosystem/blob/master/REVIEWING.md)

Both CSFLE pages from docs-ecosystem redirect to the main CSFLE landing page on the Server manual.

This content currently only exists in v6.0 which is a future version. Ticketed future work in https://jira.mongodb.org/browse/DOCSP-22897

JIRA - <https://jira.mongodb.org/browse/DOCSP-22076>
Staging - <https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/NNNNN/>

mut-redirects produced these redirects from the file:

```
Redirect 301 /docs/drivers/security https://mongodb.com/docs/v6.0/core/security-client-side-encryption/
Redirect 301 /docs/drivers/security/client-side-field-level-encryption-guide https://mongodb.com/docs/v6.0/core/security-client-side-encryption/
Redirect 301 /docs/drivers/security/client-side-field-level-encryption-local-key-to-kms https://mongodb.com/docs/v6.0/core/security-client-side-encryption/
Redirect 301 /docs/drivers/use-cases/client-side-field-level-encryption-guide https://mongodb.com/docs/v6.0/core/security-client-side-encryption/
Redirect 301 /docs/drivers/use-cases/client-side-field-level-encryption-local-key-to-kms https://mongodb.com/docs/v6.0/core/security-client-side-encryption/
Redirect 301 /docs/drivers/use-cases/sensitive-data-encryption https://mongodb.com/docs/v6.0/core/security-client-side-encryption/
```

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
