### PR TITLE
091222: Fix source constant in code

### DIFF
--- a/source/includes/stable-api-snippets/java-rs-client.java
+++ b/source/includes/stable-api-snippets/java-rs-client.java
@@ -10,7 +10,7 @@ import com.mongodb.reactivestreams.client.MongoClients;
 // Replace <connection string> with your MongoDB deployment's connection string.
 ConnectionString connString = new ConnectionString("<connection string>");
 
-// Set the version of the {+stable-api+} on the client.
+// Set the Stable API version on the client.
 ServerApi serverApi = ServerApi.builder()
         .version(ServerApiVersion.V1)
          .build();

--- a/source/includes/stable-api-snippets/pymongo-client.py
+++ b/source/includes/stable-api-snippets/pymongo-client.py
@@ -4,5 +4,5 @@ from pymongo.server_api import ServerApi
 # Replace <connection string> with your MongoDB deployment's connection string.
 conn_str = "<connection string>"
 
-# Set the version of the {+stable-api+} on the client.
+# Set the Stable API version on the client.
 client = pymongo.MongoClient(conn_str, server_api=ServerApi('1'), serverSelectionTimeoutMS=5000)

--- a/source/includes/stable-api-snippets/scala-client.scala
+++ b/source/includes/stable-api-snippets/scala-client.scala
@@ -6,7 +6,7 @@ import org.mongodb.scala._
 // Replace <connection string> with your MongoDB deployment's connection string.
 val uri = "<connection string>"
 
-// Set the version of the {+stable-api+} on the client.
+// Set the Stable API version on the client.
 val mongoClientSettings = MongoClientSettings.builder().applyConnectionString(ConnectionString(uri))
     .serverApi(ServerApi.builder().version(ServerApiVersion.V1).build())
     .build()


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-ecosystem/blob/master/REVIEWING.md)

Issue: snooty does not replace source constants in code-block component.
Fix: Replace source constant with value.

JIRA - None
Staging:
[PyMongo](https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/091222-fix-version-constant-in-code/pymongo/#stable-api)
[Scala](https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/091222-fix-version-constant-in-code/scala/#stable-api)
[Java RS](https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/091222-fix-version-constant-in-code/reactive-streams/#stable-api)


## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
