### PR TITLE
DOCSP-26394 Remove Rust 1.x from Compatibility Table

### DIFF
--- a/source/includes/mongodb-compatibility-table-rust.rst
+++ b/source/includes/mongodb-compatibility-table-rust.rst
@@ -12,7 +12,7 @@
      - MongoDB 4.2
      - MongoDB 4.0
      - MongoDB 3.6
-   * - 2.3 [#2.3-limitation]_
+   * - 2.3 [#2.2-limitation]_
      - ⊛
      - ✓
      - ✓
@@ -42,11 +42,6 @@
      - ✓
 
 The Rust driver is not compatible with MongoDB server versions older than 3.6.
-
-.. [#2.3-limitation] The Rust driver does not support Decimal128,
-   :ref:`Client-Side Field Level Encryption <manual-csfle-feature>`,
-   :manual:`GridFS </core/gridfs/>`, and
-   :manual:`OCSP </core/security-transport-encryption/>`.
 
 .. [#2.2-limitation] The Rust driver does not support Decimal128,
    :ref:`Client-Side Field Level Encryption <manual-csfle-feature>`,

--- a/source/includes/mongodb-compatibility-table-rust.rst
+++ b/source/includes/mongodb-compatibility-table-rust.rst
@@ -40,13 +40,6 @@
      - ✓
      - ✓
      - ✓
-   * - 1.1 [#limitations]_
-     - ⊛
-     - ⊛
-     - ✓
-     - ✓
-     - ✓
-     - ✓
 
 The Rust driver is not compatible with MongoDB server versions older than 3.6.
 


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-ecosystem/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-26394>
Staging - <https://docs-mongodborg-staging.corp.mongodb.com/drivers/docsworker-xlarge/DOCSP-26394-remove-rust-1.x/>

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
