### PR TITLE
DOCSP-27193: update c docs links to use https

### DIFF
--- a/source/c.txt
+++ b/source/c.txt
@@ -21,11 +21,11 @@ Download the required libraries, ``libmongoc`` and ``libbson``,  from
 `mongoc.org <https://mongoc.org/libmongoc/current/installing.html>`__
 or set up a runnable project by following our tutorial.
 
-- `Tutorial <http://mongoc.org/libmongoc/current/tutorial.html>`__
+- `Tutorial <https://mongoc.org/libmongoc/current/tutorial.html>`__
 
-- `Usage Guide <http://mongoc.org/libmongoc/current/index.html>`__
+- `Usage Guide <https://mongoc.org/libmongoc/current/index.html>`__
 
-- `API Reference <http://mongoc.org/libmongoc/current/api.html>`_
+- `API Reference <https://mongoc.org/libmongoc/current/api.html>`_
 
 - `Changelog <https://github.com/mongodb/mongo-c-driver/releases>`__
 
@@ -36,7 +36,7 @@ Installation
 ------------
 
 See `Installing the MongoDB C Driver (libmongoc) and BSON library (libbson)
-<http://mongoc.org/libmongoc/current/installing.html>`__.
+<https://mongoc.org/libmongoc/current/installing.html>`__.
 
 
 .. _connect-atlas-c-driver:
@@ -74,7 +74,7 @@ Connect to MongoDB Atlas
 
 .. include:: /includes/serverless-compatibility.rst
 
-See `Advanced Connections <http://mongoc.org/libmongoc/current/advanced-connections.html>`__
+See `Advanced Connections <https://mongoc.org/libmongoc/current/advanced-connections.html>`__
 for more ways to connect.
 
 {+stable-api+}


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-ecosystem/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-27193>
Staging - https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/DOCSP-27193-https-c-driver/c/

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Are all the links working?
