### PR TITLE
DOCSP-28339: Adding Rust 2.4 to the compatibility table.

### DIFF
--- a/source/includes/mongodb-compatibility-table-rust.rst
+++ b/source/includes/mongodb-compatibility-table-rust.rst
@@ -12,6 +12,13 @@
      - MongoDB 4.2
      - MongoDB 4.0
      - MongoDB 3.6
+   * - 2.4 [#2.2-limitation]_
+     - ⊛
+     - ✓
+     - ✓
+     - ✓
+     - ✓
+     - ✓
    * - 2.3 [#2.2-limitation]_
      - ⊛
      - ✓


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-ecosystem/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-28339>
Staging - <https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/DOCSP-28339/rust/#compatibility>

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Are all the links working?
