### PR TITLE
DOCSP-28326: add stableapi to php connection snippet

### DIFF
--- a/source/includes/connection-snippets/scram/php-connection-no-stableapi.php
+++ b/source/includes/connection-snippets/scram/php-connection-no-stableapi.php
@@ -1,0 +1,15 @@
+<?php
+
+require_once __DIR__ . '/vendor/autoload.php';
+use MongoDB\Client;
+
+$client = new Client('<connection string>');
+
+try {
+    $database = $client->admin;
+    $cursor = $database->command(['ping' => 1]);
+    echo "Pinged your deployment. You successfully connected to MongoDB!\n";
+} catch (Exception $e) {
+    echo $e->getMessage();
+}
+?>

--- a/source/includes/connection-snippets/scram/php-connection-no-stableapi.php
+++ b/source/includes/connection-snippets/scram/php-connection-no-stableapi.php
@@ -1,17 +1,18 @@
 <?php
+
+use Exception;
 use MongoDB\Client;
 
 // Replace the placeholder with your Atlas connection string
 $uri = '<connection string>';
+
 // Create a new client and connect to the server
-$client = new Client($uri);
+$client = new MongoDB\Client($uri);
 
 try {
     // Send a ping to confirm a successful connection
-    $database = $client->admin;
-    $cursor = $database->command(['ping' => 1]);
+    $client->selectDatabase('admin')->command(['ping' => 1]);
     echo "Pinged your deployment. You successfully connected to MongoDB!\n";
 } catch (Exception $e) {
-    echo $e->getMessage();
+    printf($e->getMessage());
 }
-?>

--- a/source/includes/connection-snippets/scram/php-connection-no-stableapi.php
+++ b/source/includes/connection-snippets/scram/php-connection-no-stableapi.php
@@ -1,11 +1,13 @@
 <?php
-
-require_once __DIR__ . '/vendor/autoload.php';
 use MongoDB\Client;
 
-$client = new Client('<connection string>');
+// Replace the placeholder with your Atlas connection string
+$uri = '<connection string>';
+// Create a new client and connect to the server
+$client = new Client($uri);
 
 try {
+    // Send a ping to confirm a successful connection
     $database = $client->admin;
     $cursor = $database->command(['ping' => 1]);
     echo "Pinged your deployment. You successfully connected to MongoDB!\n";

--- a/source/includes/connection-snippets/scram/php-connection.php
+++ b/source/includes/connection-snippets/scram/php-connection.php
@@ -1,13 +1,18 @@
 <?php
-
-require_once __DIR__ . '/vendor/autoload.php';
 use MongoDB\Client;
 use MongoDB\Driver\ServerApi;
 
+// Replace the placeholder with your Atlas connection string
+$uri = '<connection string>';
+
+// Specify Stable API version 1
 $serverApi = new ServerApi(ServerApi::V1);
-$client = new Client('<connection string>', [], ['serverApi' => $serverApi]);
+
+// Create a new client and connect to the server
+$client = new Client($uri, [], ['serverApi' => $serverApi]);
 
 try {
+    // Send a ping to confirm a successful connection
     $database = $client->admin;
     $cursor = $database->command(['ping' => 1]);
     echo "Pinged your deployment. You successfully connected to MongoDB!\n";

--- a/source/includes/connection-snippets/scram/php-connection.php
+++ b/source/includes/connection-snippets/scram/php-connection.php
@@ -1,0 +1,17 @@
+<?php
+
+require_once __DIR__ . '/vendor/autoload.php';
+use MongoDB\Client;
+use MongoDB\Driver\ServerApi;
+
+$serverApi = new ServerApi(ServerApi::V1);
+$client = new Client('<connection string>', [], ['serverApi' => $serverApi]);
+
+try {
+    $database = $client->admin;
+    $cursor = $database->command(['ping' => 1]);
+    echo "Pinged your deployment. You successfully connected to MongoDB!\n";
+} catch (Exception $e) {
+    echo $e->getMessage();
+}
+?>

--- a/source/includes/connection-snippets/scram/php-connection.php
+++ b/source/includes/connection-snippets/scram/php-connection.php
@@ -1,4 +1,6 @@
 <?php
+
+use Exception;
 use MongoDB\Client;
 use MongoDB\Driver\ServerApi;
 
@@ -6,17 +8,15 @@ use MongoDB\Driver\ServerApi;
 $uri = '<connection string>';
 
 // Specify Stable API version 1
-$serverApi = new ServerApi(ServerApi::V1);
+$apiVersion = new ServerApi(ServerApi::V1);
 
 // Create a new client and connect to the server
-$client = new Client($uri, [], ['serverApi' => $serverApi]);
+$client = new MongoDB\Client($uri, [], ['serverApi' => $apiVersion]);
 
 try {
     // Send a ping to confirm a successful connection
-    $database = $client->admin;
-    $cursor = $database->command(['ping' => 1]);
+    $client->selectDatabase('admin')->command(['ping' => 1]);
     echo "Pinged your deployment. You successfully connected to MongoDB!\n";
 } catch (Exception $e) {
-    echo $e->getMessage();
+    printf($e->getMessage());
 }
-?>

--- a/source/php.txt
+++ b/source/php.txt
@@ -106,19 +106,33 @@ Additional installation instructions may be found in the
 Connect to MongoDB Atlas
 ------------------------
 
-.. include:: /includes/atlas-connect-blurb.rst
+You can use the following connection snippet to test your connection to
+your MongoDB deployment on Atlas:
 
-.. code-block:: php
+.. literalinclude:: /includes/connection-snippets/scram/php-connection.php
+   :language: php
 
-   <?php
+This connection snippet uses the {+stable-api+} feature which you can use when
+connecting to MongoDB Server v5.0 and later and the PHP driver v1.9 and 
+later.
 
-   $client = new MongoDB\Client(
-       'mongodb+srv://<username>:<password>@<cluster-address>/test?retryWrites=true&w=majority'
-   );
+When you use this feature, you can update your driver or server without 
+worrying about backward compatibility issues with any commands covered by the
+{+stable-api+}.
 
-   $db = $client->test;
+.. include:: /includes/stable-api-notice.rst
 
-.. include:: /includes/serverless-compatibility.rst
+.. _connect-atlas-no-stable-api-php-driver:
+
+Connect to MongoDB Atlas Without the Stable API
+-----------------------------------------------
+
+If you are using a version of MongoDB or the driver doesn't support the
+{+stable-api+}, you can use the following code snippet to test your connection
+to your MongoDB deployment on Atlas:
+
+.. literalinclude:: /includes/connection-snippets/scram/php-connection-no-stableapi.php
+   :language: php
 
 Connect to a MongoDB Server on Your Local Machine
 -------------------------------------------------

--- a/source/php.txt
+++ b/source/php.txt
@@ -127,7 +127,7 @@ worrying about backward compatibility issues with any commands covered by the
 Connect to MongoDB Atlas Without the Stable API
 -----------------------------------------------
 
-If you are using a version of MongoDB or the driver doesn't support the
+If you are using a version of MongoDB or the driver that doesn't support the
 {+stable-api+}, you can use the following code snippet to test your connection
 to your MongoDB deployment on Atlas:
 


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-ecosystem/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-28326
Staging - https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/DOCSP-28326-php-stableapi/php/#connect-to-mongodb-atlas

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [N/A] Are all the links working?
