### PR TITLE
DOCSP-28561: update rust connection snippets with stable api

### DIFF
--- a/source/includes/connection-snippets/scram/rust-connection-async.rs
+++ b/source/includes/connection-snippets/scram/rust-connection-async.rs
@@ -1,0 +1,26 @@
+use mongodb::{bson::doc, options::{ClientOptions, ServerApi, ServerApiVersion}, Client};
+
+#[tokio::main]
+async fn main() -> mongodb::error::Result<()> {
+    // Replace the placeholder with your Atlas connection string
+    let uri = "<connection string>";
+    let mut client_options =
+        ClientOptions::parse(uri)
+            .await?;
+
+    // Set the server_api field of the client_options object to Stable API version 1
+    let server_api = ServerApi::builder().version(ServerApiVersion::V1).build();
+    client_options.server_api = Some(server_api);
+
+    // Create a new client and connect to the server
+    let client = Client::with_options(client_options)?;
+
+    // Send a ping to confirm a successful connection
+    client
+        .database("admin")
+        .run_command(doc! {"ping": 1}, None)
+        .await?;
+    println!("Pinged your deployment. You successfully connected to MongoDB!");
+
+    Ok(())
+}

--- a/source/includes/connection-snippets/scram/rust-connection-no-stableapi-async.rs
+++ b/source/includes/connection-snippets/scram/rust-connection-no-stableapi-async.rs
@@ -1,0 +1,22 @@
+use mongodb::{bson::doc, options::ClientOptions, Client};
+
+#[tokio::main]
+async fn main() -> mongodb::error::Result<()> {
+    // Replace the placeholder with your Atlas connection string
+    let uri = "<connection string>";
+    let mut client_options =
+        ClientOptions::parse(uri)
+            .await?;
+
+    // Create a new client and connect to the server
+    let client = Client::with_options(client_options)?;
+
+    // Send a ping to confirm a successful connection
+    client
+        .database("admin")
+        .run_command(doc! {"ping": 1}, None)
+        .await?;
+    println!("Pinged your deployment. You successfully connected to MongoDB!");
+
+    Ok(())
+}

--- a/source/includes/connection-snippets/scram/rust-connection-no-stableapi-sync.rs
+++ b/source/includes/connection-snippets/scram/rust-connection-no-stableapi-sync.rs
@@ -1,0 +1,17 @@
+use mongodb::{bson::doc, sync::Client};
+
+fn main() -> mongodb::error::Result<()> {
+    // Replace the placeholder with your Atlas connection string
+    let uri = "<connection string>";
+
+    // Create a new client and connect to the server
+    let client = Client::with_uri_str(uri)?;
+
+    // Send a ping to confirm a successful connection
+    client
+        .database("admin")
+        .run_command(doc! {"ping": 1}, None)?;
+    println!("Pinged your deployment. You successfully connected to MongoDB!");
+
+    Ok(())
+}

--- a/source/includes/connection-snippets/scram/rust-connection-sync.rs
+++ b/source/includes/connection-snippets/scram/rust-connection-sync.rs
@@ -1,0 +1,23 @@
+use mongodb::{bson::doc, options::{ClientOptions, ServerApi, ServerApiVersion}, sync::Client};
+
+fn main() -> mongodb::error::Result<()> {
+    // Replace the placeholder with your Atlas connection string
+    let uri = "<connection string>";
+    let mut client_options =
+        ClientOptions::parse(uri)?;
+
+    // Set the server_api field of the client_options object to Stable API version 1
+    let server_api = ServerApi::builder().version(ServerApiVersion::V1).build();
+    client_options.server_api = Some(server_api);
+
+    // Create a new client and connect to the server
+    let client = Client::with_options(client_options)?;
+
+    // Send a ping to confirm a successful connection
+    client
+        .database("admin")
+        .run_command(doc! {"ping": 1}, None)?;
+    println!("Pinged your deployment. You successfully connected to MongoDB!");
+
+    Ok(())
+}

--- a/source/rust.txt
+++ b/source/rust.txt
@@ -28,8 +28,6 @@ or set up a runnable project with examples from our Usage Guide.
 
 - `Source Code <https://github.com/mongodb/mongo-rust-driver/>`__
 
-
-
 Installation
 ------------
 
@@ -40,10 +38,10 @@ See `Installation <https://github.com/mongodb/mongo-rust-driver#Installation>`__
 Connect to MongoDB Atlas
 ------------------------
 
-Select from the :guilabel:`Sync` or :guilabel:`Async` tabs below for
-corresponding connection code samples.
-
-.. include:: /includes/atlas-connect-blurb.rst
+You can use the connection snippets in the following tabs to test your
+connection to your MongoDB deployment on Atlas. Select from the
+:guilabel:`Sync` or :guilabel:`Async` tabs below for corresponding
+connection code samples.
 
 .. tabs::
 
@@ -54,36 +52,8 @@ corresponding connection code samples.
       different runtime, see
       `Configuring the async runtime <https://github.com/mongodb/mongo-rust-driver#configuring-the-async-runtime>`__.
 
-      .. code-block:: rust
-
-         use mongodb::{bson::doc, options::ClientOptions, Client};
-
-         #[tokio::main]
-         async fn main() -> mongodb::error::Result<()> {
-             // Parse your connection string into an options struct
-             let mut client_options =
-                 ClientOptions::parse("mongodb+srv://<username>:<password>@<cluster-url>/test?w=majority")
-                     .await?;
-
-             // Manually set an option
-             client_options.app_name = Some("Rust Demo".to_string());
-
-             // Get a handle to the cluster
-             let client = Client::with_options(client_options)?;
-
-             // Ping the server to see if you can connect to the cluster
-             client
-                 .database("admin")
-                 .run_command(doc! {"ping": 1}, None)
-                 .await?;
-             println!("Connected successfully.");
-
-             // List the names of the databases in that cluster
-             for db_name in client.list_database_names(None, None).await? {
-                 println!("{}", db_name);
-             }
-             Ok(())
-         }
+      .. literalinclude:: /includes/connection-snippets/scram/rust-connection-async.rs
+         :language: rust
 
    .. tab:: Sync
       :tabid: rust-sync
@@ -92,30 +62,51 @@ corresponding connection code samples.
       `Enabling the sync API <https://github.com/mongodb/mongo-rust-driver#enabling-the-sync-api>`__
       for more details.
 
-      .. code-block:: rust
+      .. literalinclude:: /includes/connection-snippets/scram/rust-connection-sync.rs
+         :language: rust
+      
+This connection snippet uses the {+stable-api+} feature which you can use when
+connecting to MongoDB Server v5.0 and later and the Rust driver v2.0 and 
+later.
 
-         use mongodb::{bson::doc, sync::Client};
+When you use this feature, you can update your driver or server without 
+worrying about backward compatibility issues with any commands covered by the
+{+stable-api+}.
 
-         fn main() -> mongodb::error::Result<()> {
-             // Get a handle to the cluster
-             let client = Client::with_uri_str(
-                 "mongodb+srv://<username>:<password>@<cluster-url>/test?w=majority",
-             )?;
+.. include:: /includes/stable-api-notice.rst
 
-             // Ping the server to see if you can connect to the cluster
-             client
-                 .database("admin")
-                 .run_command(doc! {"ping": 1}, None)?;
-             println!("Connected successfully.");
+.. _connect-atlas-no-stable-api-php-driver:
 
-             // List the names of the databases in that cluster
-             for db_name in client.list_database_names(None, None)? {
-                 println!("{}", db_name);
-             }
-             Ok(())
-         }
+Connect to MongoDB Atlas Without the Stable API
+-----------------------------------------------
 
-.. include:: /includes/serverless-compatibility.rst
+If you are using a version of MongoDB or the driver that doesn't support the
+{+stable-api+}, you can use the connection snippets in the following
+tabs to test your connection to your MongoDB deployment on Atlas. Select from the
+:guilabel:`Sync` or :guilabel:`Async` tabs below for corresponding
+connection code samples.
+
+.. tabs::
+
+   .. tab:: Async
+      :tabid: rust-async-no-stableapi
+
+      The default async runtime used by the driver is ``tokio``. To use a
+      different runtime, see
+      `Configuring the async runtime <https://github.com/mongodb/mongo-rust-driver#configuring-the-async-runtime>`__.
+
+      .. literalinclude:: /includes/connection-snippets/scram/rust-connection-no-stableapi-async.rs
+         :language: rust
+
+   .. tab:: Sync
+      :tabid: rust-sync-no-stableapi
+
+      Make sure you enabled the sync API. See
+      `Enabling the sync API <https://github.com/mongodb/mongo-rust-driver#enabling-the-sync-api>`__
+      for more details.
+
+      .. literalinclude:: /includes/connection-snippets/scram/rust-connection-no-stableapi-sync.rs
+         :language: rust
 
 Connect to a MongoDB Server on Your Local Machine
 -------------------------------------------------


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-ecosystem/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-28561
Staging - https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/DOCSP-28561-rust-stableapi/rust/#connect-to-mongodb-atlas

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Are all the links working?
