### PR TITLE
DOCSP-28835: Added links for C and C++ driver pages

### DIFF
--- a/source/c.txt
+++ b/source/c.txt
@@ -25,11 +25,17 @@ or set up a runnable project by following our tutorial.
 
 - `Usage Guide <https://mongoc.org/libmongoc/current/index.html>`__
 
+- `MongoDB Developer Center <https://www.mongodb.com/developer/languages/c/>`__
+
 - `API Reference <https://mongoc.org/libmongoc/current/api.html>`_
 
 - `Changelog <https://github.com/mongodb/mongo-c-driver/releases>`__
 
 - `Source Code <https://github.com/mongodb/mongo-c-driver>`__
+
+- `Examples <https://github.com/mongodb/mongo-c-driver/tree/master/src/libmongoc/examples>`__
+
+- `Additional BSON Examples <https://github.com/mongodb/mongo-c-driver/tree/master/src/libbson/examples>`__
 
 
 Installation

--- a/source/cxx.txt
+++ b/source/cxx.txt
@@ -25,11 +25,15 @@ or set up a runnable project by following our tutorial.
 
 - `Usage Guide <https://mongocxx.org/mongocxx-v3/>`__
 
+- `MongoDB Developer Center <https://www.mongodb.com/developer/languages/cpp/>`__
+
 - `API Reference <https://mongocxx.org/api/current/>`_
 
 - `Changelog <https://github.com/mongodb/mongo-cxx-driver/releases>`__
 
 - `Source Code <https://github.com/mongodb/mongo-cxx-driver/>`__
+
+- `Examples <https://github.com/mongodb/mongo-cxx-driver/tree/master/examples>`__
 
 
 Installation


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-ecosystem/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-28835>
Staging - <https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/DOCSP-28835/c/> and <https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/DOCSP-28835/cxx/>

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Are all the links working?
