### PR TITLE
Updating PHP libraries, 2023

### DIFF
--- a/source/php-libraries.txt
+++ b/source/php-libraries.txt
@@ -140,5 +140,5 @@ Miscellaneous Projects
 - `PHPfastcache <https://github.com/PHPSocialNetwork/phpfastcache>`_ provides a simple,
   high-performance backend cache system for MongoDB.
 
-- `XHgui <https://github.com/perftools/xhgui>`_ a Web interface for XHProf profiling data,
-storing it in MongoDB
+- `XHGui <https://github.com/perftools/xhgui>`_, a web interface for the XHProf profiler
+  that stores profiling data in MongoDB.

--- a/source/php-libraries.txt
+++ b/source/php-libraries.txt
@@ -24,7 +24,7 @@ Stand-alone Libraries
   `Laminas <https://github.com/doctrine/DoctrineMongoODMModule>`_ (formerly Zend
   Framework) are also available.
 
-- `Mongo Queue PHP <https://github.com/dominionenterprises/mongo-queue-php>`_ is
+- `Mongo Queue PHP <https://github.com/traderinteractive/mongo-queue-php>`_ is
   a PHP message queue, which uses MongoDB as a backend.
 
 - `Mongo PHP Adapter <https://github.com/alcaeus/mongo-php-adapter>`_ is a
@@ -32,12 +32,6 @@ Stand-alone Libraries
   the legacy ``mongo`` extension and the new ``mongodb`` extension. It provides
   the API of the legacy driver on top of the new driver and library, which
   allows for compatibility with PHP 7.
-
-- `Mongodm <https://github.com/purekid/mongodm>`_ is a MongoDB ORM that includes
-  support for references, embedded documents, and multilevel inheritance.
-
-- `MongoDB Transistor <https://github.com/bjori/mongo-php-transistor>`_:
-  Lightweight ODM that utilizes the driver's Persistable interface.
 
 - `Mongolid <https://github.com/leroy-merlin-br/mongolid>`_: A fast ODM for PHP and
   MongoDB, which implements both ActiveRecord and DataMapper design patterns and
@@ -89,24 +83,6 @@ Libraries for the ``mongo`` Extension
 
 Stand-alone Libraries
 ~~~~~~~~~~~~~~~~~~~~~
-
-- `Mongator ODM <https://github.com/mongator/mongator/>`_ is an easy, powerful,
-  and ultrafast ODM for PHP and MongoDB. It is a fork of the
-  `Mandango ODM <https://github.com/mandango/mandango>`_.
-
-- `MongoFilesystem <https://github.com/AlexanderMitov/MongoFilesystem>`_
-  implements a hierarchical file system using MongoDB as a storage engine. The
-  library uses GridFS for storing the files and a standard collection for the
-  folder information. There is an object-oriented representation of the folders
-  and files in the filesystem and rich API for performing operations. The
-  library also implements renderers for JSON, HTML, and XML.
-
-- `Mongofill <https://github.com/mongofill/mongofill>`_ is a pure PHP
-  implementation of the ``mongo`` extension, which means that it can be used
-  with HHVM. A separate `mongofill-hhvm
-  <https://github.com/mongofill/mongofill-hhvm>`_ package provides a `libbson
-  <https://github.com/mongodb/libbson>`_ extension for HHVM, which allows for
-  more performant BSON encoding and decoding.
 
 - `MongoQueue <https://github.com/lunaru/mongoqueue>`_ is a PHP queue that
   allows for moving tasks and jobs into an asynchronous process for completion
@@ -160,3 +136,9 @@ Miscellaneous Projects
 - `PeclMongoPhpDoc <https://github.com/localgod/PeclMongoPhpDoc>`_ provides
   skeleton classes for the ``mongo`` extension, which may be used to support
   autocomplete and inline documentation for IDEs.
+
+- `PHPfastcache <https://github.com/PHPSocialNetwork/phpfastcache>`_ provides a simple
+high-performance backend cache system for MongoDB.
+
+- `XHgui <https://github.com/perftools/xhgui>`_ a Web interface for XHProf profiling data,
+storing it in MongoDB

--- a/source/php-libraries.txt
+++ b/source/php-libraries.txt
@@ -137,8 +137,8 @@ Miscellaneous Projects
   skeleton classes for the ``mongo`` extension, which may be used to support
   autocomplete and inline documentation for IDEs.
 
-- `PHPfastcache <https://github.com/PHPSocialNetwork/phpfastcache>`_ provides a simple
-high-performance backend cache system for MongoDB.
+- `PHPfastcache <https://github.com/PHPSocialNetwork/phpfastcache>`_ provides a simple,
+  high-performance backend cache system for MongoDB.
 
 - `XHgui <https://github.com/perftools/xhgui>`_ a Web interface for XHProf profiling data,
 storing it in MongoDB


### PR DESCRIPTION
https://github.com/traderinteractive/mongo-queue-php has the wrong link, it links to a fork by a user rather than the main https://github.com/purekid/mongodm hasn't been updated since 2017, should be removed https://github.com/bjori/mongo-php-transistor hasnt been updated since 2016, should be removed https://github.com/mongator/mongator/ hasn't been updated since 2014, should be removed https://github.com/aleksmitov/MongoFilesystem hasn't been updated since 2015, should be removed https://github.com/mongofill/mongofill has been archived and isn't maintained since 2016, removing  Adding https://github.com/PHPSocialNetwork/phpfastcache  Adding XHGUI

# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-ecosystem/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-NNNNN>
Staging - <https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/NNNNN/>

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
