### PR TITLE
DOCSP-28488: create redirects for bad urls

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -22,6 +22,7 @@ raw: docs/drivers/use-cases/sensitive-data-encryption -> ${manual}/core/csfle/
 ### Redirects for Legacy Drivers Content
 ###
 raw: docs/drivers/tutorials -> ${base}/
+raw: docs/drivers/perl -> ${base}/community-supported-drivers/
 raw: docs/drivers/perl-internals -> ${base}/community-supported-drivers/
 raw: docs/drivers/downloads -> ${base}/
 raw: docs/drivers/syntax-table -> ${base}/
@@ -160,12 +161,17 @@ raw: docs/ecosystem/tools/http-interfaces -> ${devhub}/
 raw: docs/ecosystem/security/client-side-field-level-encryption-guide -> https://www.mongodb.com/docs/manual/core/csfle/
 raw: docs/ecosystem/drivers -> ${base}/
 raw: docs/ecosystem/drivers/scala -> ${base}/scala/
-raw: docs/ecosystem/drivers/ruby -> ${base}/ruby/
+raw: docs/ecosystem/drivers/ruby -> https://www.mongodb.com/docs/ruby-driver/current/
 raw: docs/ecosystem/drivers/python -> ${base}/python/
 raw: docs/ecosystem/drivers/pymongo/ -> ${base}/pymongo/
-raw: docs/ecosystem/drivers/perl/ -> ${base}/
+raw: docs/ecosystem/drivers/perl/ -> ${base}/community-supported-drivers/
 raw: docs/ecosystem/drivers/php -> ${base}/php/
-raw: docs/ecosystem/drivers/node/ -> ${base}/node/
+raw: docs/ecosystem/drivers/node/ -> ${base}/node/current/
+raw: docs/ecosystem/drivers/csharp/ -> ${base}/csharp/current/
+raw: docs/ecosystem/drivers/java/ -> ${base}/java-drivers/
+raw: docs/ecosystem/drivers/c/ -> ${base}/c/
+raw: docs/ecosystem/drivers/driver-compatibility-reference/ -> ${base}/about-compatibility/
+raw: docs/ecosystem/ -> ${base}/
 
 # Redirect for outdated Drivers & ODMs page
 


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-ecosystem/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-28488>
Staging - None

Comments refer to the CSV attached to https://jira.mongodb.org/browse/DOCSP-28477

mut-redirects output diff:

```

9a10
> Redirect 301 /docs/drivers/perl https://www.mongodb.com/docs/drivers/community-supported-drivers/
116c117
< Redirect 301 /docs/ecosystem/drivers/ruby https://www.mongodb.com/docs/drivers/ruby/
---
> Redirect 301 /docs/ecosystem/drivers/ruby https://www.mongodb.com/docs/ruby-driver/current/
119c120
< Redirect 301 /docs/ecosystem/drivers/perl/ https://www.mongodb.com/docs/drivers/
---
> Redirect 301 /docs/ecosystem/drivers/perl/ https://www.mongodb.com/docs/drivers/community-supported-drivers/
121c122,127
< Redirect 301 /docs/ecosystem/drivers/node/ https://www.mongodb.com/docs/drivers/node/
---
> Redirect 301 /docs/ecosystem/drivers/node/ https://www.mongodb.com/docs/drivers/node/current/
> Redirect 301 /docs/ecosystem/drivers/csharp/ https://www.mongodb.com/docs/drivers/csharp/current/
> Redirect 301 /docs/ecosystem/drivers/java/ https://www.mongodb.com/docs/drivers/java-drivers/
> Redirect 301 /docs/ecosystem/drivers/c/ https://www.mongodb.com/docs/drivers/c/
> Redirect 301 /docs/ecosystem/drivers/driver-compatibility-reference/ https://www.mongodb.com/docs/drivers/about-compatibility/
> Redirect 301 /docs/ecosystem/ https://www.mongodb.com/docs/drivers/

```



## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
