### PR TITLE
docs-16146 - update link

### DIFF
--- a/source/index.txt
+++ b/source/index.txt
@@ -119,7 +119,7 @@ Featured Community-Supported Libraries
 
    .. card::
       :cta: Mongoose
-      :url: https://mongoosejs.com/docs/guide.html
+      :url: https://mongoosejs.com/docs/index.html
       :icon: /figures/icons/mongoose.svg
       :icon-alt: Mongoose icon
    


### PR DESCRIPTION
Ticket completed, but updating link per Alex B.'s Jira comment.

There are errors in staging because the icons are pulled in from docs-assets for the deployed site, but not for staging.

# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-ecosystem/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCS-16146
Staging - https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/docs-16146-update-link/

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
