### PR TITLE
DOCSP-30778: Add temp redirect to Kotlin Coroutine page

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -202,3 +202,7 @@ raw: docs/drivers/drivers/ -> ${base}/
 # Redirect for outdated Community Drivers page
 
 raw: docs/drivers/community-supported-drivers/ -> ${base}/
+
+# Temporary redirect for Kotlin page 
+
+raw: docs/drivers/kotlin/ -> https://www.mongodb.com/docs/drivers/kotlin/coroutine/


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-ecosystem/blob/master/REVIEWING.md)

Add temporary redirect from `/docs/drivers/kotlin` to the [Kotlin Coroutine Driver page](https://www.mongodb.com/docs/drivers/kotlin/coroutine/current/) until the main Kotlin landing page is available (see https://github.com/mongodb/docs-ecosystem/pull/879/ -- updates to be merged and deployed next week)

JIRA - <https://jira.mongodb.org/browse/DOCSP-30778>
Staging - <https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/NNNNN/>

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
