### PR TITLE
Temporary removal of Kotlin coroutine driver links

### DIFF
--- a/source/includes/help-links-kotlin.rst
+++ b/source/includes/help-links-kotlin.rst
@@ -3,4 +3,6 @@ How to get help
 
 - Ask questions on our :community-forum:`MongoDB Community Forums <>`.
 - Visit our :technical-support:`Support Channels </>`.
-- See `Issues & Help <https://www.mongodb.com/docs/drivers/kotlin/coroutine/current/issues-and-help/>`__.
+
+.. 
+   - See `Issues & Help <https://www.mongodb.com/docs/drivers/kotlin/coroutine/current/issues-and-help/>`__.

--- a/source/kotlin-sync.txt
+++ b/source/kotlin-sync.txt
@@ -22,7 +22,7 @@ official MongoDB driver for synchronous Kotlin applications.
 - `Source Code <https://github.com/mongodb/mongo-java-driver/tree/master/driver-kotlin-sync/>`__
 
 If you need to make asynchronous calls between your application and MongoDB with 
-coroutines, use the :driver:`MongoDB Kotlin Coroutine Driver </kotlin/coroutine/current/>` 
+coroutines, use the MongoDB Kotlin Coroutine Driver (coming soon)
 instead of the Sync Driver.
 
 Installation

--- a/source/kotlin.txt
+++ b/source/kotlin.txt
@@ -9,7 +9,6 @@ MongoDB Kotlin Drivers
 .. toctree::
    :titlesonly:
 
-   Kotlin Coroutine Driver <https://www.mongodb.com/docs/drivers/kotlin/coroutine/current/>
    /kotlin-sync.txt
 
 .. contents:: On this page
@@ -26,7 +25,6 @@ drivers. You can add one of the following drivers to your application
 to work with MongoDB in Kotlin:
 
 - Use the
-  `Kotlin Coroutine Driver <https://www.mongodb.com/docs/drivers/kotlin/coroutine/current>`__
-  for Kotlin applications using coroutines.
+  Kotlin Coroutine Driver for Kotlin applications using coroutines (coming soon).
 
 - Use the :doc:`Kotlin Sync Driver </kotlin-sync>` for synchronous Kotlin applications.


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-ecosystem/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-NNNNN>
Staging - <https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/NNNNN/>

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
