### PR TITLE
PHPORM-26: Remove legacy projects

### DIFF
--- a/source/php-libraries.txt
+++ b/source/php-libraries.txt
@@ -12,20 +12,14 @@ PHP Libraries, Frameworks, and Tools
    :depth: 2
    :class: singlecol
 
-Libraries for the ``mongodb`` Extension
----------------------------------------
-
 Stand-alone Libraries
-~~~~~~~~~~~~~~~~~~~~~
+---------------------
 
 - `Doctrine MongoDB ODM <https://github.com/doctrine/mongodb-odm>`_ is a library
   that provides object mapping functionality for MongoDB. Integrations with
   `Symfony <https://github.com/doctrine/DoctrineMongoDBBundle>`_ and
   `Laminas <https://github.com/doctrine/DoctrineMongoODMModule>`_ (formerly Zend
   Framework) are also available.
-
-- `Mongo Queue PHP <https://github.com/traderinteractive/mongo-queue-php>`_ is
-  a PHP message queue, which uses MongoDB as a backend.
 
 - `Mongo PHP Adapter <https://github.com/alcaeus/mongo-php-adapter>`_ is a
   userland library designed to act as an adapter between applications relying on
@@ -38,17 +32,13 @@ Stand-alone Libraries
   supports embedded and referenced documents. An integration with
   `Laravel <https://github.com/leroy-merlin-br/mongolid-laravel>`__ is also available.
 
-- `Yadm <https://github.com/makasim/yadm>`_ is a MongoDB ODM written for the
-  **mongodb** extension. It is schema-less and supports fast object hydration
-  and persistence, which makes it well-suited for modeling aggregation results.
-
 - `Xenus <https://github.com/abellion/xenus>`_ is an elegant MongoDB ODM
   that supports events, relationships, embedded documents, and more. An
   integration with `Laravel <https://github.com/abellion/xenus-laravel>`__ is
   also available, which adds support for failed jobs, migrations, and events.
 
 Framework Integrations
-~~~~~~~~~~~~~~~~~~~~~~
+----------------------
 
 - Drupal
 
@@ -66,79 +56,38 @@ Framework Integrations
 
 - Symfony
 
+  - The components `Lock <https://symfony.com/doc/current/components/lock.html#mongodbstore>`_ and
+    `Session <https://symfony.com/doc/current/session.html#store-sessions-in-a-nosql-database-mongodb>`_
+    can be configured to use MongoDB.
+
   - `MongoDB Bundle <https://github.com/facile-it/mongodb-bundle>`_: A
     simple bundle service integration for the official `PHP library
     <https://github.com/mongodb/mongo-php-library>`_. Allows you to configure
     connections to different databases or clusters and includes a convenient
     query profiler.
 
+  - `DoctrineMongoDBBundle Symfony <https://github.com/doctrine/DoctrineMongoDBBundle>`_
+    This bundle integrates the Object Document Mapper (ODM) into Symfony so
+    that you can persist and retrieve objects to and from MongoDB.
+
 - Yii2
 
   - `MongoDB Extension for Yii 2
-    <http://www.yiiframework.com/doc-2.0/ext-mongodb-index.html>`_ provides
+    <https://www.yiiframework.com/extension/yiisoft/yii2-mongodb>`_ provides
     MongoDB integration for Yii framework 2.0.
 
-Libraries for the ``mongo`` Extension
--------------------------------------
-
-Stand-alone Libraries
-~~~~~~~~~~~~~~~~~~~~~
-
-- `MongoQueue <https://github.com/lunaru/mongoqueue>`_ is a PHP queue that
-  allows for moving tasks and jobs into an asynchronous process for completion
-  in the background. The queue is managed by MongoDB.
-
-- `MongoRecord <https://github.com/lunaru/mongorecord>`_ is a PHP MongoDB ORM
-  layer built on top of the ``mongo`` PECL extension.
-
-- `PHPMongo ODM <https://github.com/sokil/php-mongo>`_ is an ODM with support
-  for validation, relations, events, document versioning, and database
-  migrations. Although it is written for the legacy ``mongo`` extension, it is
-  tested to work with the ``mongodb`` extension using `Mongo PHP Adapter
-  <https://github.com/alcaeus/mongo-php-adapter>`_.
-
-- `Yamop <https://github.com/mawelous/yamop>`_ is yet another MongoDB ODM for
-  PHP. It works like the standard MongoDB PHP extension interface but returns
-  objects instead of arrays (as ODM). An integration with
-  `Laravel <https://github.com/mawelous/yamop-laravel>`_ is also available.
-
-Framework Integrations
-~~~~~~~~~~~~~~~~~~~~~~
-
-- Drupal
-
-  - `MongoDB integration for Drupal <https://www.drupal.org/project/mongodb>`_.
-    This is a collection of several modules which allow sites to store different
-    types of Drupal data in MongoDB. Support for the ``mongo`` extension exists
-    for Drupal 6, 7, and 8.
-
-- Kohana
-
-  - `MangoDB <https://github.com/Wouterrr/mangodb>`_: Mango is an ORM and
-    ActiveRecord-like library that takes full advantage of MongoDB's features.
-
-  - `MongoDB PHP ODM <https://github.com/colinmollenhour/mongodb-php-odm>`_ is a
-    simple but powerful set of wrappers for using MongoDB in PHP. It is designed
-    for use with Kohana 3 but should integrate easily with any PHP
-    application.
-
-- Yii 1.x
-
-  - `MongoYii <http://github.com/Sammaye/MongoYii/>`_ is ActiveRecord ORM for
-    Yii framework 1.x that supports MongoDB.
-
-  - `Yii MongoDB Driver <https://github.com/fromYukki/Yii-MongoDB-Driver>`_ is a
-    MongoDB extension for Yii framework 1.x.
-
 Miscellaneous Projects
-~~~~~~~~~~~~~~~~~~~~~~
+----------------------
 
-- `PeclMongoPhpDoc <https://github.com/localgod/PeclMongoPhpDoc>`_ provides
-  skeleton classes for the ``mongo`` extension, which may be used to support
-  autocomplete and inline documentation for IDEs.
+- `PHP Cache <https://github.com/php-cache/mongodb-adapter/>` is a PSR-6 cache
+  implementation using MongoDB. It is a part of the PHP Cache organisation.
 
 - `PHPfastcache <https://github.com/PHPSocialNetwork/phpfastcache>`_ provides a simple,
   high-performance backend cache system for MongoDB.
+
+- `Enqueue <https://github.com/php-enqueue/mongodb>` is production ready,
+   battle-tested messaging solution for PHP. It provides a common way for programs
+   to create, send, read messages.
 
 - `XHGui <https://github.com/perftools/xhgui>`_, a web interface for the XHProf profiler
   that stores profiling data in MongoDB.

--- a/source/php-libraries.txt
+++ b/source/php-libraries.txt
@@ -67,7 +67,7 @@ Framework Integrations
     query profiler.
 
   - `DoctrineMongoDBBundle Symfony <https://github.com/doctrine/DoctrineMongoDBBundle>`_
-    This bundle integrates the Object Document Mapper (ODM) into Symfony so
+    This bundle integrates the Doctrine Object Document Mapper (ODM) into Symfony so
     that you can persist and retrieve objects to and from MongoDB.
 
 - Yii2


### PR DESCRIPTION
The [legacy mongo extension](https://github.com/mongodb/mongo-php-driver-legacy) for PHP is EOL since February 2022. The lib that were not updated to support the new [`ext-mongodb`](https://pecl.php.net/package/mongodb) must not be highlighted.

Adding some new libs and components that are actively maintained and used.

# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-ecosystem/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/PHPORM-26>
Staging - <https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/NNNNN/>

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
