### PR TITLE
DOCSP-31115: Demonstrate including the Composer autoloader

### DIFF
--- a/source/php.txt
+++ b/source/php.txt
@@ -97,6 +97,14 @@ The preferred method of installing the PHP library is with
 
    $ composer require mongodb/mongodb
 
+Once you have installed the library, ensure that your application includes
+Composer's autoloader as in the following example:
+
+.. code-block:: php
+
+   <?php
+
+   require_once __DIR__ . '/vendor/autoload.php';
 
 Additional installation instructions may be found in the
 `library documentation <https://www.mongodb.com/docs/php-library/current/tutorial/install-php-library/>`_.


### PR DESCRIPTION
This is analogous to reminding users to load the extension in php.ini. Both are also covered in the linked PHPLIB docs, but it makes sense to duplicate the information here for users that don't click through.

# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-ecosystem/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-31115>

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
