### PR TITLE
DOCSP-30714: fix June 2023 404s

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -176,18 +176,21 @@ raw: docs/drivers/tutorial/write-a-tumblelog-application-with-flask-mongoengine 
 
 # Redirects for ecosystem that were previously handled in Fastly
 
-raw: docs/ecosystem/use-cases/pre-aggregated-reports -> ${devhub}/
-raw: docs/ecosystem/tutorial/authenticate-with-java-driver -> ${devhub}/
-raw: docs/ecosystem/use-cases/client-side-field-level-encryption-guide -> https://www.mongodb.com/docs/manual/core/csfle/
-raw: docs/ecosystem/tools/http-interfaces -> ${devhub}/
+raw: docs/ecosystem/use-cases/pre-aggregated-reports/ -> ${devhub}/
+raw: docs/ecosystem/tutorial/authenticate-with-java-driver/ -> ${devhub}/
+raw: docs/ecosystem/use-cases/client-side-field-level-encryption-guide/ -> https://www.mongodb.com/docs/manual/core/csfle/
+raw: docs/ecosystem/tools/http-interfaces/ -> ${devhub}/
+raw: docs/ecosystem/tools/http-interface/ -> ${devhub}/
 raw: docs/ecosystem/security/client-side-field-level-encryption-guide -> https://www.mongodb.com/docs/manual/core/csfle/
-raw: docs/ecosystem/drivers -> ${base}/
-raw: docs/ecosystem/drivers/scala -> ${base}/scala/
-raw: docs/ecosystem/drivers/ruby -> https://www.mongodb.com/docs/ruby-driver/current/
-raw: docs/ecosystem/drivers/python -> ${base}/python/
+raw: docs/ecosystem/driver/ -> ${base}/
+raw: docs/ecosystem/drivers/ -> ${base}/
+raw: docs/ecosystem/drivers/node-js/ -> $${base}/node/current/
+raw: docs/ecosystem/drivers/scala/ -> ${base}/scala/
+raw: docs/ecosystem/drivers/ruby/ -> https://www.mongodb.com/docs/ruby-driver/current/
+raw: docs/ecosystem/drivers/python/ -> ${base}/python/
 raw: docs/ecosystem/drivers/pymongo/ -> ${base}/pymongo/
 raw: docs/ecosystem/drivers/perl/ -> ${base}/
-raw: docs/ecosystem/drivers/php -> ${base}/php/
+raw: docs/ecosystem/drivers/php/ -> ${base}/php/
 raw: docs/ecosystem/drivers/node/ -> ${base}/node/current/
 raw: docs/ecosystem/drivers/csharp/ -> ${base}/csharp/current/
 raw: docs/ecosystem/drivers/java/ -> ${base}/java-drivers/
@@ -195,9 +198,26 @@ raw: docs/ecosystem/drivers/c/ -> ${base}/c/
 raw: docs/ecosystem/drivers/driver-compatibility-reference/ -> ${base}/about-compatibility/
 raw: docs/ecosystem/ -> ${base}/
 
-# Redirect for outdated Drivers & ODMs page
+# Redirects for drivers/drivers/
 
 raw: docs/drivers/drivers/ -> ${base}/
+raw: docs/drivers/drivers/c/ -> ${base}/c/
+raw: docs/drivers/drivers/cxx/ -> ${base}/cxx/
+raw: docs/drivers/drivers/csharp/ -> ${base}/csharp/current/
+raw: docs/drivers/drivers/go/ -> ${base}/go/current/
+raw: docs/drivers/drivers/java/ -> ${base}/java-drivers/
+raw: docs/drivers/drivers/kotlin/ -> ${base}/kotlin-drivers/
+raw: docs/drivers/drivers/node/ -> $${base}/node/current/
+raw: docs/drivers/drivers/php/ -> ${base}/php/
+raw: docs/drivers/drivers/python/ -> ${base}/python/
+raw: docs/drivers/drivers/pymongo/ -> ${base}/pymongo/
+raw: docs/drivers/drivers/ruby/ -> https://www.mongodb.com/docs/ruby-driver/current/
+raw: docs/drivers/drivers/rust/ -> ${base}/rust/
+raw: docs/drivers/drivers/scala/ -> ${base}/scala/
+raw: docs/drivers/drivers/swift/ -> ${base}/swift/
+
+raw: docs/drivers/drivers/driver-compatibility-reference -> ${base}/
+
 
 # Redirect for outdated Community Drivers page
 


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-ecosystem/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-301714>
Staging - None

Added redirects for the malformed URLs that refer to this repo.

mut-redirects output diff:

```
110,113c110,114
< Redirect 301 /docs/ecosystem/use-cases/pre-aggregated-reports https://www.mongodb.com/developer/
< Redirect 301 /docs/ecosystem/tutorial/authenticate-with-java-driver https://www.mongodb.com/developer/
< Redirect 301 /docs/ecosystem/use-cases/client-side-field-level-encryption-guide https://www.mongodb.com/docs/manual/core/csfle/
< Redirect 301 /docs/ecosystem/tools/http-interfaces https://www.mongodb.com/developer/
---
> Redirect 301 /docs/ecosystem/use-cases/pre-aggregated-reports/ https://www.mongodb.com/developer/
> Redirect 301 /docs/ecosystem/tutorial/authenticate-with-java-driver/ https://www.mongodb.com/developer/
> Redirect 301 /docs/ecosystem/use-cases/client-side-field-level-encryption-guide/ https://www.mongodb.com/docs/manual/core/csfle/
> Redirect 301 /docs/ecosystem/tools/http-interfaces/ https://www.mongodb.com/developer/
> Redirect 301 /docs/ecosystem/tools/http-interface/ https://www.mongodb.com/developer/
115,118c116,121
< Redirect 301 /docs/ecosystem/drivers https://www.mongodb.com/docs/drivers/
< Redirect 301 /docs/ecosystem/drivers/scala https://www.mongodb.com/docs/drivers/scala/
< Redirect 301 /docs/ecosystem/drivers/ruby https://www.mongodb.com/docs/ruby-driver/current/
< Redirect 301 /docs/ecosystem/drivers/python https://www.mongodb.com/docs/drivers/python/
---
> Redirect 301 /docs/ecosystem/driver/ https://www.mongodb.com/docs/drivers/
> Redirect 301 /docs/ecosystem/drivers/ https://www.mongodb.com/docs/drivers/
> Redirect 301 /docs/ecosystem/drivers/node-js/ $https://www.mongodb.com/docs/drivers/node/current/
> Redirect 301 /docs/ecosystem/drivers/scala/ https://www.mongodb.com/docs/drivers/scala/
> Redirect 301 /docs/ecosystem/drivers/ruby/ https://www.mongodb.com/docs/ruby-driver/current/
> Redirect 301 /docs/ecosystem/drivers/python/ https://www.mongodb.com/docs/drivers/python/
121c124
< Redirect 301 /docs/ecosystem/drivers/php https://www.mongodb.com/docs/drivers/php/
---
> Redirect 301 /docs/ecosystem/drivers/php/ https://www.mongodb.com/docs/drivers/php/
128a132,146
> Redirect 301 /docs/drivers/drivers/c/ https://www.mongodb.com/docs/drivers/c/
> Redirect 301 /docs/drivers/drivers/cxx/ https://www.mongodb.com/docs/drivers/cxx/
> Redirect 301 /docs/drivers/drivers/csharp/ https://www.mongodb.com/docs/drivers/csharp/current/
> Redirect 301 /docs/drivers/drivers/go/ https://www.mongodb.com/docs/drivers/go/current/
> Redirect 301 /docs/drivers/drivers/java/ https://www.mongodb.com/docs/drivers/java-drivers/
> Redirect 301 /docs/drivers/drivers/kotlin/ https://www.mongodb.com/docs/drivers/kotlin-drivers/
> Redirect 301 /docs/drivers/drivers/node/ $https://www.mongodb.com/docs/drivers/node/current/
> Redirect 301 /docs/drivers/drivers/php/ https://www.mongodb.com/docs/drivers/php/
> Redirect 301 /docs/drivers/drivers/python/ https://www.mongodb.com/docs/drivers/python/
> Redirect 301 /docs/drivers/drivers/pymongo/ https://www.mongodb.com/docs/drivers/pymongo/
> Redirect 301 /docs/drivers/drivers/ruby/ https://www.mongodb.com/docs/ruby-driver/current/
> Redirect 301 /docs/drivers/drivers/rust/ https://www.mongodb.com/docs/drivers/rust/
> Redirect 301 /docs/drivers/drivers/scala/ https://www.mongodb.com/docs/drivers/scala/
> Redirect 301 /docs/drivers/drivers/swift/ https://www.mongodb.com/docs/drivers/swift/
> Redirect 301 /docs/drivers/drivers/driver-compatibility-reference https://www.mongodb.com/docs/drivers/
```



## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
