### PR TITLE
DOCSP-32358: add information about component compatibility tables

### DIFF
--- a/source/about-compatibility.txt
+++ b/source/about-compatibility.txt
@@ -69,7 +69,7 @@ In the **Component Compatibility** tables, the columns indicate versions of
 the driver, and the rows indicate the component package names.
 
 The table cells indicate which versions of the component packages are
-compatible for the driver version specified in that column.
+compatible with the driver version specified in that column.
 
 If the table cell value is blank, the component package is incompatible with
 the version of the driver version specified in that column.

--- a/source/about-compatibility.txt
+++ b/source/about-compatibility.txt
@@ -32,10 +32,9 @@ The circled asterisks (⊛) indicate that the driver version works with
 that specific version of MongoDB server, but may not be able to access all
 the features.
 
-If you are **upgrading your server version**, your current driver should
-continue to function properly, but may not be able to access the features
-introduced in the newer server versions. We recommend using the newest
-compatible driver when upgrading your server version.
+If you are **upgrading your server version**, check whether your current driver
+version is compatible. We recommend using the newest compatible driver when
+upgrading your server version.
 
 If you are **upgrading your driver version**, you can use the table to
 identify which version you need to access all the newest features included

--- a/source/about-compatibility.txt
+++ b/source/about-compatibility.txt
@@ -28,6 +28,10 @@ The check marks (✓) indicate that the driver can access **all the
 features** of that specific version of MongoDB server unless those features
 have been deprecated or removed.
 
+The circled asterisks (⊛) indicate that the driver version works with
+that specific version of MongoDB server, but may not be able to access all
+the features.
+
 If you are **upgrading your server version**, your current driver should
 continue to function properly, but may not be able to access the features
 introduced in the newer server versions. We recommend using the newest
@@ -58,3 +62,16 @@ labeled with major release versions of the driver.
 
 The check marks (✓) indicate that the code in the driver is fully
 compatible with the version of the language.
+
+Component Compatibility Tables
+------------------------------
+
+In the **Component Compatibility** tables, the columns indicate versions of
+the driver, and the rows indicate the component package names.
+
+The table cells indicate which versions of the component packages are
+compatible for the driver version specified in that column.
+
+If the table cell value is blank, the component package is incompatible with
+the version of the driver version specified in that column.
+


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-ecosystem/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-32358>
Staging:

- [Modifications to existing section](https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/DOCSP-32358-component-compatibility/about-compatibility/#mongodb-compatibility-tables-1)
- [New section
](https://docs-mongodbcom-staging.corp.mongodb.com/drivers/docsworker-xlarge/DOCSP-32358-component-compatibility/about-compatibility/#component-compatibility-tables)


## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [ ] Are all the links working?
