### PR TITLE
(DOCSP-32292) Adds mention of Atlas to drivers landing page

### DIFF
--- a/source/index.txt
+++ b/source/index.txt
@@ -9,8 +9,10 @@ Start Developing with MongoDB
 .. meta:: 
    :keywords: r, elixir, prisma, mongoose
    
-Connect your application to your database with one of the official MongoDB 
-libraries.
+Connect your application to your `MongoDB Atlas database
+<https://www.mongodb.com/docs/atlas>`__ or `self-hosted MongoDB
+database <https://www.mongodb.com/docs/manual/installation>`__ with
+one of the official MongoDB libraries.
 
 The following libraries are officially supported by MongoDB. MongoDB actively
 develops new features, adds performance enhancements, fixes bugs, and applies 

--- a/source/index.txt
+++ b/source/index.txt
@@ -9,10 +9,10 @@ Start Developing with MongoDB
 .. meta:: 
    :keywords: r, elixir, prisma, mongoose
    
-Connect your application to your `MongoDB Atlas database
-<https://www.mongodb.com/docs/atlas>`__ or `self-hosted MongoDB
-database <https://www.mongodb.com/docs/manual/installation>`__ with
-one of the official MongoDB libraries.
+You can connect your application to your MongoDB Atlas deployment or a
+self-hosted MongoDB cluster by using one of the official MongoDB
+libraries. To learn more about Atlas, see :atlas:`What is MongoDB Atlas? </>`. To learn how to download and install a self-hosted
+MongoDB cluster, see :manual:`Install MongoDB </installation>`.
 
 The following libraries are officially supported by MongoDB. MongoDB actively
 develops new features, adds performance enhancements, fixes bugs, and applies 


### PR DESCRIPTION
# Pull Request Info
Adds mention of Atlas to the top of the drivers landing page as part of the Atlas-centric Top 250 initiative.

Build: https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=650af8c2492df295cf198d7a

[PR Reviewing Guidelines](https://github.com/mongodb/docs-ecosystem/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-32292?filter=46607
Staging - https://preview-mongodbsarahsimpers.gatsbyjs.io/drivers/DOCSP-32292/

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST? Multiple errors in the build are unrelated to this change
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
