### PR TITLE
DOCS-16420- Update footnote to show correct Python version

### DIFF
--- a/source/includes/language-compatibility-table-python.rst
+++ b/source/includes/language-compatibility-table-python.rst
@@ -66,7 +66,7 @@
      - ✓
      - ✓
 
-.. [#ssl-4.0-issue] Versions of Python 4.10 and later are not compatible with
+.. [#ssl-4.0-issue] Versions of Python 3.10 and later are not compatible with
    TLS/SSL for versions of MongoDB 4.0 and earlier. See the `PyMongo documentation <https://pymongo.readthedocs.io/en/stable/examples/tls.html#python-3-10-incompatibilities-with-tls-ssl-on-mongodb-4-0>`__
    for more information.
 .. [#three-six-compat] Pymongo 4.1 requires Python 3.6.2 or later.


### PR DESCRIPTION
# Pull Request Info
Typo in compatibility table footnote was showing v4.10 instead of v3.10

[PR Reviewing Guidelines](https://github.com/mongodb/docs-ecosystem/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCS-16420
Staging - https://preview-mongodbjordansmith721.gatsbyjs.io/drivers/DOCS-16420-pymongo-footnote-fix/pymongo/#compatibility-1

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
