### PR TITLE
DOCSP-34260: fix c code for memory leak

### DIFF
--- a/source/c.txt
+++ b/source/c.txt
@@ -4,6 +4,17 @@
 MongoDB C Driver
 ================
 
+.. facet::
+   :name: programming_language
+   :values: c
+
+.. facet::
+   :name: genre
+   :values: reference
+
+.. meta:: 
+   :keywords: code example, get started, sample app
+
 .. contents:: On this page
    :local:
    :backlinks: none

--- a/source/includes/connection-snippets/scram/c-connection-no-stable-api.c
+++ b/source/includes/connection-snippets/scram/c-connection-no-stable-api.c
@@ -12,7 +12,7 @@ int main(void) {
     // Initialize the MongoDB C Driver.
     mongoc_init();
 
-    client = mongoc_client_new("mongodb+srv://admin:<password>@cluster0.rdwcnhq.mongodb.net/?retryWrites=true&w=majority");
+    client = mongoc_client_new("<connection string>");
     if (!client) {
         fprintf(stderr, "failed to create a MongoDB client\n");
         rc = 1;

--- a/source/includes/connection-snippets/scram/c-connection-no-stable-api.c
+++ b/source/includes/connection-snippets/scram/c-connection-no-stable-api.c
@@ -14,7 +14,7 @@ int main(void) {
 
     client = mongoc_client_new("<connection string>");
     if (!client) {
-        fprintf(stderr, "failed to create a MongoDB client\n");
+        fprintf(stderr, "Failed to create a MongoDB client.\n");
         rc = 1;
         goto cleanup;
     }
@@ -22,7 +22,7 @@ int main(void) {
     // Get a handle on the "admin" database.
     database = mongoc_client_get_database(client, "admin");
     if (!database) {
-        fprintf(stderr, "failed to get a MongoDB database handle\n");
+        fprintf(stderr, "Failed to get a MongoDB database handle.\n");
         rc = 1;
         goto cleanup;
     }

--- a/source/includes/connection-snippets/scram/c-connection-no-stable-api.c
+++ b/source/includes/connection-snippets/scram/c-connection-no-stable-api.c
@@ -1,42 +1,52 @@
 #include <mongoc/mongoc.h>
 
-int main (int argc, char **argv)
-{
-	mongoc_client_t *client = NULL;
-	bson_error_t error = {0};
-	mongoc_database_t *database = NULL;
-	bson_t *command = NULL, reply;
+int main(void) {
+    mongoc_client_t *client = NULL;
+    bson_error_t error = {0};
+    mongoc_database_t *database = NULL;
+    bson_t *command = NULL;
+    bson_t reply = BSON_INITIALIZER;
+    int rc = 0;
+    bool ok = true;
 
+    // Initialize the MongoDB C Driver.
+    mongoc_init();
 
-	// Initialize the MongoDB C Driver.
-	mongoc_init ();
+    client = mongoc_client_new("mongodb+srv://admin:<password>@cluster0.rdwcnhq.mongodb.net/?retryWrites=true&w=majority");
+    if (!client) {
+        fprintf(stderr, "failed to create a MongoDB client\n");
+        rc = 1;
+        goto cleanup;
+    }
 
-	// Replace the <connection string> with your MongoDB deployment's connection string.
-	client = mongoc_client_new("<connection string>");
+    // Get a handle on the "admin" database.
+    database = mongoc_client_get_database(client, "admin");
+    if (!database) {
+        fprintf(stderr, "failed to get a MongoDB database handle\n");
+        rc = 1;
+        goto cleanup;
+    }
 
-	// Get a handle on the "admin" database.
-	database = mongoc_client_get_database (client, "admin");
-  
-	// Ping the database.
-	command = BCON_NEW("ping", BCON_INT32(1));
-	if (mongoc_database_command_simple(database, command, NULL, &reply, &error))
-	{
-		printf("Pinged your deployment. You successfully connected to MongoDB!\n");
-	}
-	else
-	{
-		// Error condition.
-		printf("Error: %s\n", error.message);
-		return 0;
-	}
-  
+    // Ping the database.
+    command = BCON_NEW("ping", BCON_INT32(1));
+    ok = mongoc_database_command_simple(
+        database, command, NULL, &reply, &error
+    );
+    if (!ok) {
+        fprintf(stderr, "error: %s\n", error.message);
+        rc = 1;
+        goto cleanup;
+    }
+    bson_destroy(&reply);
 
-	// Perform Cleanup.
-	bson_destroy (&reply);
-	bson_destroy (command);
-	mongoc_database_destroy (database);
-	mongoc_client_destroy (client);
-	mongoc_cleanup ();
+    printf("Pinged your deployment. You successfully connected to MongoDB!\n");
 
-	return 0;
+// Perform cleanup.
+cleanup:
+    bson_destroy(command);
+    mongoc_database_destroy(database);
+    mongoc_client_destroy(client);
+    mongoc_cleanup();
+
+    return rc;
 }

--- a/source/includes/connection-snippets/scram/c-connection.c
+++ b/source/includes/connection-snippets/scram/c-connection.c
@@ -1,51 +1,69 @@
 #include <mongoc/mongoc.h>
 
-int main (int argc, char **argv)
-{
-  mongoc_client_t *client = NULL;
-  bson_error_t error = {0};
-  mongoc_server_api_t *api = NULL;
-  mongoc_database_t *database = NULL;
-  bson_t *command = NULL, reply;
+int main(void) {
+    mongoc_client_t *client = NULL;
+    bson_error_t error = {0};
+    mongoc_server_api_t *api = NULL;
+    mongoc_database_t *database = NULL;
+    bson_t *command = NULL;
+    bson_t reply = BSON_INITIALIZER;
+    int rc = 0;
+    bool ok = true;
 
-  // Initialize the MongoDB C Driver.
-  mongoc_init ();
+    // Initialize the MongoDB C Driver.
+    mongoc_init();
 
-  // Replace the <connection string> with your MongoDB deployment's connection string.
-  client = mongoc_client_new("<connection string>");
+    client = mongoc_client_new("mongodb+srv://admin:<password>@cluster0.rdwcnhq.mongodb.net/?retryWrites=true&w=majority");
+    if (!client) {
+        fprintf(stderr, "failed to create a MongoDB client\n");
+        rc = 1;
+        goto cleanup;
+    }
 
-  // Set the version of the Stable API on the client.
-  api = mongoc_server_api_new (MONGOC_SERVER_API_V1);
-  if (!mongoc_client_set_server_api (client, api, &error))
-  {
-	  // Error condition.
-	  printf("Error: %s\n", error.message);
-	  return 0;
-  }
+    // Set the version of the Stable API on the client.
+    api = mongoc_server_api_new(MONGOC_SERVER_API_V1);
+    if (!api) {
+        fprintf(stderr, "failed to create a MongoDB server API\n");
+        rc = 1;
+        goto cleanup;
+    }
 
-  // Get a handle on the "admin" database.
-  database = mongoc_client_get_database (client, "admin");
-  
-  // Ping the database.
-  command = BCON_NEW("ping", BCON_INT32(1));
-  if (mongoc_database_command_simple(database, command, NULL, &reply, &error))
-  {
+    ok = mongoc_client_set_server_api(client, api, &error);
+    if (!ok) {
+        fprintf(stderr, "error: %s\n", error.message);
+        rc = 1;
+        goto cleanup;
+    }
+
+    // Get a handle on the "admin" database.
+    database = mongoc_client_get_database(client, "admin");
+    if (!database) {
+        fprintf(stderr, "failed to get a MongoDB database handle\n");
+        rc = 1;
+        goto cleanup;
+    }
+
+    // Ping the database.
+    command = BCON_NEW("ping", BCON_INT32(1));
+    ok = mongoc_database_command_simple(
+        database, command, NULL, &reply, &error
+    );
+    if (!ok) {
+        fprintf(stderr, "error: %s\n", error.message);
+        rc = 1;
+        goto cleanup;
+    }
+    bson_destroy(&reply);
+
     printf("Pinged your deployment. You successfully connected to MongoDB!\n");
-  }
-  else
-  {
-    // Error condition.
-    printf("Error: %s\n", error.message);
-    return 0;
-  }
-  
 
-  // Perform Cleanup.
-  bson_destroy (&reply);
-  bson_destroy (command);
-  mongoc_database_destroy (database);
-  mongoc_client_destroy (client);
-  mongoc_cleanup ();
+// Perform cleanup.
+cleanup:
+    bson_destroy(command);
+    mongoc_database_destroy(database);
+    mongoc_server_api_destroy(api);
+    mongoc_client_destroy(client);
+    mongoc_cleanup();
 
-  return 0;
+    return rc;
 }

--- a/source/includes/connection-snippets/scram/c-connection.c
+++ b/source/includes/connection-snippets/scram/c-connection.c
@@ -15,7 +15,7 @@ int main(void) {
 
     client = mongoc_client_new("<connection string>");
     if (!client) {
-        fprintf(stderr, "failed to create a MongoDB client\n");
+        fprintf(stderr, "Failed to create a MongoDB client.\n");
         rc = 1;
         goto cleanup;
     }
@@ -23,7 +23,7 @@ int main(void) {
     // Set the version of the Stable API on the client.
     api = mongoc_server_api_new(MONGOC_SERVER_API_V1);
     if (!api) {
-        fprintf(stderr, "failed to create a MongoDB server API\n");
+        fprintf(stderr, "Failed to create a MongoDB server API.\n");
         rc = 1;
         goto cleanup;
     }
@@ -38,7 +38,7 @@ int main(void) {
     // Get a handle on the "admin" database.
     database = mongoc_client_get_database(client, "admin");
     if (!database) {
-        fprintf(stderr, "failed to get a MongoDB database handle\n");
+        fprintf(stderr, "Failed to get a MongoDB database handle.\n");
         rc = 1;
         goto cleanup;
     }

--- a/source/includes/connection-snippets/scram/c-connection.c
+++ b/source/includes/connection-snippets/scram/c-connection.c
@@ -13,7 +13,7 @@ int main(void) {
     // Initialize the MongoDB C Driver.
     mongoc_init();
 
-    client = mongoc_client_new("mongodb+srv://admin:<password>@cluster0.rdwcnhq.mongodb.net/?retryWrites=true&w=majority");
+    client = mongoc_client_new("<connection string>");
     if (!client) {
         fprintf(stderr, "failed to create a MongoDB client\n");
         rc = 1;


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-ecosystem/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-34260>
Staging - 
- [stable api](https://preview-mongodbrustagir.gatsbyjs.io/drivers/DOCSP-34260-update-c-code-memory-leak/c/#connect-to-mongodb-atlas)
- [no stable api](https://preview-mongodbrustagir.gatsbyjs.io/drivers/DOCSP-34260-update-c-code-memory-leak/c/#connect-to-mongodb-atlas-without-the-stable-api)

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
