### PR TITLE
DOCSP-35623: updates to change php-drivers URL to php

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -212,7 +212,7 @@ raw: docs/drivers/drivers/go/ -> ${base}/go/current/
 raw: docs/drivers/drivers/java/ -> ${base}/java-drivers/
 raw: docs/drivers/drivers/kotlin/ -> ${base}/kotlin-drivers/
 raw: docs/drivers/drivers/node/ -> $${base}/node/current/
-raw: docs/drivers/drivers/php/ -> ${base}/php-drivers/
+raw: docs/drivers/drivers/php/ -> ${base}/php/
 raw: docs/drivers/drivers/python/ -> ${base}/python-drivers/
 raw: docs/drivers/drivers/pymongo/ -> ${base}/pymongo/
 raw: docs/drivers/drivers/ruby/ -> ${base}/ruby-drivers/
@@ -229,6 +229,6 @@ raw: docs/drivers/community-supported-drivers/ -> ${base}/
 
 # Redirects for consistent language-spcific driver landing pages
 
-raw:  docs/drivers/php/ -> ${base}/php-drivers/
+raw:  docs/drivers/php-drivers/ -> ${base}/php/
 raw:  docs/drivers/python/ -> ${base}/python-drivers/
 raw:  docs/drivers/ruby/ -> ${base}/ruby-drivers/

--- a/snooty.toml
+++ b/snooty.toml
@@ -3,7 +3,7 @@ title = "MongoDB Drivers"
 
 toc_landing_pages = [
     "/python-drivers",
-    "/php-drivers",
+    "/php",
     "/java-drivers",
     "/kotlin-drivers",
     "/use-cases",

--- a/source/includes/help-links-php.rst
+++ b/source/includes/help-links-php.rst
@@ -4,5 +4,6 @@ How to get help
 - Ask questions on our :community-forum:`MongoDB Community Forums <>`.
 - Visit our :technical-support:`Support Channels </>`.
 - File an issue or feature request in JIRA under one of the following:
-  - `Extension <https://jira.mongodb.org/projects/PHPC/summary>`_
-  - `Library <https://jira.mongodb.org/projects/PHPLIB/summary>`_
+
+  - `Extension <https://jira.mongodb.org/projects/PHPC/summary>`__
+  - `Library <https://jira.mongodb.org/projects/PHPLIB/summary>`__

--- a/source/index.txt
+++ b/source/index.txt
@@ -6,17 +6,17 @@
 Start Developing with MongoDB
 =============================
 
-.. meta:: 
+.. meta::
    :description: Connect your application to your MongoDB Atlas deployment or a self-hosted MongoDB cluster by using one of the official MongoDB client libraries.
    :keywords: r, elixir, prisma, mongoose
-   
+
 You can connect your application to your MongoDB Atlas deployment or a
 self-hosted MongoDB cluster by using one of the official MongoDB
 libraries. To learn more about Atlas, see :atlas:`What is MongoDB Atlas? </>`. To learn how to download and install a self-hosted
 MongoDB cluster, see :manual:`Install MongoDB </installation>`.
 
 The following libraries are officially supported by MongoDB. MongoDB actively
-develops new features, adds performance enhancements, fixes bugs, and applies 
+develops new features, adds performance enhancements, fixes bugs, and applies
 security patches to them.
 
 .. card-group::
@@ -38,7 +38,7 @@ security patches to them.
 
    .. card::
       :headline: C#
-      :url: /csharp-drivers/ 
+      :url: /csharp-drivers/
       :icon: /icons/csharp.svg
       :icon-alt: C sharp Driver icon
 
@@ -53,13 +53,13 @@ security patches to them.
       :url: /java-drivers/
       :icon: /icons/java.svg
       :icon-alt: Java Driver icon
-   
+
    .. card::
       :headline: Kotlin
       :url: /kotlin-drivers/
       :icon: /icons/kotlin.svg
       :icon-alt: Kotlin Driver icon
-   
+
    .. card::
       :headline: Node.js
       :url: https://www.mongodb.com/docs/drivers/node/current/
@@ -68,7 +68,7 @@ security patches to them.
 
    .. card::
       :headline: PHP
-      :url: /php-drivers/
+      :url: /php/
       :icon: /icons/php.svg
       :icon-alt: PHP Driver icon
 
@@ -77,7 +77,7 @@ security patches to them.
       :url: /python-drivers/
       :icon: /icons/python.svg
       :icon-alt: Python Driver icon
-   
+
    .. card::
       :headline: Ruby
       :url: /ruby-drivers/
@@ -128,7 +128,7 @@ Featured Community-Supported Libraries
       :url: https://mongoosejs.com/docs/index.html
       :icon: /icons/mongoose.svg
       :icon-alt: Mongoose icon
-   
+
    .. card::
       :cta: Prisma
       :url: https://www.prisma.io/docs/guides/database/mongodb
@@ -161,7 +161,7 @@ with MongoDB:
    Java Drivers </java-drivers>
    Kotlin Drivers </kotlin-drivers>
    Node.js Driver <https://www.mongodb.com/docs/drivers/node/current/>
-   PHP Driver </php-drivers>
+   PHP Driver </php>
    Python Drivers </python-drivers>
    Ruby Drivers  </ruby-drivers>
    Rust Driver <https://www.mongodb.com/docs/drivers/rust/current/>

--- a/source/php.txt
+++ b/source/php.txt
@@ -12,7 +12,7 @@ MongoDB PHP Driver
    :name: genre
    :values: tutorial
 
-.. meta:: 
+.. meta::
    :description: Use the PHP driver and libraries to connect to MongoDB Atlas, Enterprise, and Community database deployments.
    :keywords: code example
 
@@ -81,7 +81,7 @@ Driver Architecture
 This section describes how the components of the PHP driver work together.
 These components fit into the following general categories:
 
-- High-Level API, which includes the library and other integrations 
+- High-Level API, which includes the library and other integrations
 - Extension, which includes the extension that integrates the system libraries
 - System, which includes the C Driver, BSON library, and encryption library
 
@@ -91,7 +91,7 @@ components:
 .. figure:: /figures/PHP_driver_architecture.svg
    :alt: PHP driver component architecture
    :figwidth: 600px
-   
+
 The PHP library provides an API that is consistent with the other
 MongoDB drivers. The library is continually updated to meet cross-driver
 specifications. You must add the library as a dependency to access
@@ -179,7 +179,7 @@ your MongoDB deployment on Atlas:
 
 This connection snippet uses the {+stable-api+} feature, which you can
 enable when using the PHP driver v1.9 and later to connect to MongoDB Server
-v5.0 and later. When you use this feature, you can update your driver or server without 
+v5.0 and later. When you use this feature, you can update your driver or server without
 worrying about backward compatibility issues with any commands covered by the
 {+stable-api+}.
 


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-ecosystem/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-35623>
Staging:

- [PHP landing page](https://preview-mongodbcchomongodb.gatsbyjs.io/drivers/DOCSP-35623-rename-php-landing/php/)

Note: the [index page](https://preview-mongodbcchomongodb.gatsbyjs.io/drivers/DOCSP-35623-rename-php-landing/php/) link for PHP doesn't work due to how the button-type components are rendered on staging.

Redirects diff ("<" points to the redirects currently in the deployed branch, ">" points to the redirects in this PR):

```
140c140
< Redirect 301 /docs/drivers/drivers/php/ https://www.mongodb.com/docs/drivers/php-drivers/
---
> Redirect 301 /docs/drivers/drivers/php/ https://www.mongodb.com/docs/drivers/php/
149c149
< Redirect 301 /docs/drivers/php/ https://www.mongodb.com/docs/drivers/php-drivers/
---
> Redirect 301 /docs/drivers/php-drivers/ https://www.mongodb.com/docs/drivers/php/
```


## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [x] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
