### PR TITLE
DOCSP-35392: update laravel docs link

### DIFF
--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -1,42 +1,48 @@
-# Pull Request Reviewing Guidelines for Driver Ecosystem Documentation
+# Pull Request Reviewing Guidelines for the Driver Ecosystem Documentation
 
 Contributions to the set of documents in this repository can receive reviews from one or both of the following types of reviews:
 
 1. A **copy review**, which focuses on information structure and wording; typically performed by a MongoDB Documentation Team member
-2. A **technical review**, which addresses code snippets and the technical correctness of prose; typically performed by a MongoDB engineer.
+2. A **technical review**, which addresses code snippets and the technical correctness of prose, typically performed by a MongoDB engineer.
+
+# Which Types of Changes for which to Request a Technical Review
+
+- When the PR changes include code snippets.
+- When the PR changes include release notes, breaking changes, or upgrading versions.
+- To get alignment on specific wording of descriptions of technical information, especially for new features.
+- If in doubt, request a technical review.
+
+# What to Review
 
 See the following sections for reviewer expectations for each type of pull request (PR) review:
 
 ## Copy Review
 
-Review the structure, wording, and flow of the information in the PR, and correct it if necessary.
+A typical copy review consists of the following checks:
 
-### What to Review
-
-- Wording
+- Wording, including grammar and spelling
 - Page structure
-- Technical content to the extent of the reviewer’s understanding.
+- Technical content to the extent of the reviewer's understanding
 - Whether the PR fulfills the Acceptance Criteria described in the
-  linked JIRA ticket.
+  linked JIRA ticket
 
 ### What Not to Review
 
-Nothing is completely off-limits to a copy review of a PR -- if you notice a technical issue, it's best to call it out early.
-Copy reviewers should constrain their reviews to content within the scope of the JIRA ticket, or otherwise create PRs to address anything unrelated.
-
+Nothing is entirely off-limits to a copy review of a PR -- if you notice a technical issue, it's best to call it out early.
+Copy reviewers should constrain their reviews to content within the scope of the JIRA ticket or otherwise create PRs to address anything unrelated.
 
 ## Technical Review
 
-Review the technical accuracy and completeness of a PR and correct it if necessary.
+A typical technical review consists of the following checks:
 
-### What to Review
-
-- Code snippets; ensure the code is idiomatic and that all technical claims are correct. e.g. ("To create a `Foo`, use the `Bar.createFoo()` method")
+- Technical accuracy
+- Release notes, breaking changes, and upgrading pages; ensure the technical claims are correct.
+- Code snippets: ensure the code is idiomatic and that all technical claims are correct. e.g. ("To create a `Foo`, use the `Bar.createFoo()` method")
 - Problematic explanations that could trip up users who try to follow the documentation.
 
 ### What Not to Review
 
-While we welcome any recommendations on wording and structure, avoid blocking approval based on any copy edits. Please entrust the author to make the writing decisions based on style guidelines and team-specific writing conventions, and to create PRs to address anything they deem outside the technical review scope.
+While we welcome any recommendations on wording and structure, avoid blocking approval based on any copy edits. Please entrust the author to make the writing decisions based on style guidelines and team-specific writing conventions and to create PRs to address anything they deem outside the technical review scope.
 
 - Wording of sentences, although corrections to technical claims are welcome
 - Structure of the page

--- a/source/php-libraries.txt
+++ b/source/php-libraries.txt
@@ -60,10 +60,11 @@ Framework Integrations
 
 - Laravel
 
-  - `Laravel MongoDB <https://github.com/mongodb/laravel-mongodb>`__ is an
-    Eloquent model and Query builder that supports MongoDB by using the
-    original Laravel API. This library extends the original Laravel classes
-    and therefore uses the same methods.
+  - `Laravel MongoDB <https://www.mongodb.com/docs/drivers/php/laravel-mongodb/current/>`__
+    is MongoDB's official Eloquent model and query builder that supports 
+    MongoDB by using the original Laravel API. This package extends the PHP 
+    Laravel classes to work with MongoDB as a datastore in your Laravel 
+    application.
 
 - Symfony
 


### PR DESCRIPTION
# Pull Request Info

Includes the same update to REVIEWING.md as in this [Java docs PR](https://github.com/mongodb/docs-java/pull/509).

JIRA - <https://jira.mongodb.org/browse/DOCSP-35392>
Staging - https://preview-mongodbcchomongodb.gatsbyjs.io/drivers/DOCSP-35392-laravel-docs-link/php-libraries/

Relevant changes:
https://github.com/mongodb/docs-ecosystem/pull/940/files?diff=split&w=1#diff-9b46e5245116cd170b22d0944fa13d34aeadcc33692dd10bc8817f0514fe98e6R63-R67


## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
