### PR TITLE
fix redirect syntax error

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -211,7 +211,7 @@ raw: docs/drivers/drivers/csharp/ -> ${base}/csharp/current/
 raw: docs/drivers/drivers/go/ -> ${base}/go/current/
 raw: docs/drivers/drivers/java/ -> ${base}/java-drivers/
 raw: docs/drivers/drivers/kotlin/ -> ${base}/kotlin-drivers/
-raw: docs/drivers/drivers/node/ -> $${base}/node/current/
+raw: docs/drivers/drivers/node/ -> ${base}/node/current/
 raw: docs/drivers/drivers/php/ -> ${base}/php/
 raw: docs/drivers/drivers/python/ -> ${base}/python-drivers/
 raw: docs/drivers/drivers/pymongo/ -> ${base}/pymongo/

--- a/config/redirects
+++ b/config/redirects
@@ -188,7 +188,7 @@ raw: docs/ecosystem/tools/http-interface/ -> ${devhub}/
 raw: docs/ecosystem/security/client-side-field-level-encryption-guide -> https://www.mongodb.com/docs/manual/core/csfle/
 raw: docs/ecosystem/driver/ -> ${base}/
 raw: docs/ecosystem/drivers/ -> ${base}/
-raw: docs/ecosystem/drivers/node-js/ -> $${base}/node/current/
+raw: docs/ecosystem/drivers/node-js/ -> ${base}/node/current/
 raw: docs/ecosystem/drivers/scala/ -> ${base}/scala/
 raw: docs/ecosystem/drivers/ruby/ -> https://www.mongodb.com/docs/ruby-driver/current/
 raw: docs/ecosystem/drivers/python/ -> ${base}/python/


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-ecosystem/blob/master/REVIEWING.md)

Incorrectly formatted redirects were causing the deployment job to fail.

JIRA - None
Staging - None

Old
```
Redirect 301 /docs/ecosystem/drivers/node-js/ $https://www.mongodb.com/docs/drivers/node/current/
...
Redirect 301 /docs/drivers/drivers/node/ $https://www.mongodb.com/docs/drivers/node/current/
```

New:
```
Redirect 301 /docs/ecosystem/drivers/node-js/ https://www.mongodb.com/docs/drivers/node/current/
...
Redirect 301 /docs/drivers/drivers/node/ https://www.mongodb.com/docs/drivers/node/current/

```

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
- [ ] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
