### PR TITLE
DOCSP-38350 - fix redirects

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -48,9 +48,9 @@ raw: docs/drivers/cpp-bson-helper-functions -> https://www.mongodb.com/docs/lang
 raw: docs/drivers/cpp-to-sql-to-mongo-shell -> https://www.mongodb.com/docs/languages/cpp/drivers/current/
 raw: docs/drivers/tutorial/download-and-compile-cpp-driver-legacy -> https://mongocxx.org/legacy-v1/
 raw: docs/drivers/tutorial/authenticate-with-cpp-driver -> https://www.mongodb.com/docs/languages/cpp/drivers/current/configuration/#configuring-authentication
-raw: docs/drivers/cxx -> ${languages-base}/cpp
-raw: docs/drivers/cxx/index -> ${languages-base}/docs/drivers/cpp
-raw: /docs/languages/cxx -> ${languages-base}/cpp
+raw: docs/drivers/cxx -> ${languages-base}/cpp/drivers/current
+raw: docs/drivers/cxx/index -> ${languages-base}/cpp/drivers/current
+raw: /docs/languages/cxx -> ${languages-base}/cpp/drivers/current
 
 # csharp
 

--- a/config/redirects
+++ b/config/redirects
@@ -3,6 +3,7 @@ define: kafka https://www.mongodb.com/docs/kafka-connector/current
 define: manual https://www.mongodb.com/docs/manual
 define: atlas https://www.mongodb.com/docs/atlas
 define: devhub https://www.mongodb.com/developer
+define: languages-base https://www.mongodb.com/docs/languages
 
 # Go
 
@@ -47,9 +48,9 @@ raw: docs/drivers/cpp-bson-helper-functions -> https://www.mongodb.com/docs/lang
 raw: docs/drivers/cpp-to-sql-to-mongo-shell -> https://www.mongodb.com/docs/languages/cpp/drivers/current/
 raw: docs/drivers/tutorial/download-and-compile-cpp-driver-legacy -> https://mongocxx.org/legacy-v1/
 raw: docs/drivers/tutorial/authenticate-with-cpp-driver -> https://www.mongodb.com/docs/languages/cpp/drivers/current/configuration/#configuring-authentication
-raw: docs/drivers/cxx -> docs/drivers/cpp
-raw: docs/drivers/cxx/index -> docs/drivers/cpp
-raw: /docs/languages/cxx -> /docs/languages/cpp
+raw: docs/drivers/cxx -> ${languages-base}/docs/drivers/cpp
+raw: docs/drivers/cxx/index -> ${languages-base}/docs/drivers/cpp
+raw: /docs/languages/cxx -> ${languages-base}/cpp
 
 # csharp
 

--- a/config/redirects
+++ b/config/redirects
@@ -48,7 +48,7 @@ raw: docs/drivers/cpp-bson-helper-functions -> https://www.mongodb.com/docs/lang
 raw: docs/drivers/cpp-to-sql-to-mongo-shell -> https://www.mongodb.com/docs/languages/cpp/drivers/current/
 raw: docs/drivers/tutorial/download-and-compile-cpp-driver-legacy -> https://mongocxx.org/legacy-v1/
 raw: docs/drivers/tutorial/authenticate-with-cpp-driver -> https://www.mongodb.com/docs/languages/cpp/drivers/current/configuration/#configuring-authentication
-raw: docs/drivers/cxx -> ${languages-base}/docs/drivers/cpp
+raw: docs/drivers/cxx -> ${languages-base}/cpp
 raw: docs/drivers/cxx/index -> ${languages-base}/docs/drivers/cpp
 raw: /docs/languages/cxx -> ${languages-base}/cpp
 

--- a/config/redirects
+++ b/config/redirects
@@ -4,6 +4,7 @@ define: manual https://www.mongodb.com/docs/manual
 define: atlas https://www.mongodb.com/docs/atlas
 define: devhub https://www.mongodb.com/developer
 define: languages-base https://www.mongodb.com/docs/languages
+define: cpp-driver-base ${languages-base}/cpp/cpp-driver/current
 
 # Go
 
@@ -41,16 +42,16 @@ raw: docs/drivers/syntax-table -> ${base}/
 
 # cpp
 
-raw: docs/drivers/tutorial/download-and-compile-cpp-driver -> https://www.mongodb.com/docs/languages/cpp/drivers/current/installation/
-raw: docs/drivers/tutorial/getting-started-with-cpp-driver -> https://www.mongodb.com/docs/languages/cpp/drivers/current/tutorial/
-raw: docs/drivers/cpp-bson-array-examples -> https://www.mongodb.com/docs/languages/cpp/drivers/current/working-with-bson/
-raw: docs/drivers/cpp-bson-helper-functions -> https://www.mongodb.com/docs/languages/cpp/drivers/current/working-with-bson/
-raw: docs/drivers/cpp-to-sql-to-mongo-shell -> https://www.mongodb.com/docs/languages/cpp/drivers/current/
+raw: docs/drivers/tutorial/download-and-compile-cpp-driver -> languages/installation/
+raw: docs/drivers/tutorial/getting-started-with-cpp-driver -> ${cpp-driver-base}/tutorial/
+raw: docs/drivers/cpp-bson-array-examples -> ${cpp-driver-base}/working-with-bson/
+raw: docs/drivers/cpp-bson-helper-functions -> ${cpp-driver-base}/working-with-bson/
+raw: docs/drivers/cpp-to-sql-to-mongo-shell -> ${cpp-driver-base}
 raw: docs/drivers/tutorial/download-and-compile-cpp-driver-legacy -> https://mongocxx.org/legacy-v1/
-raw: docs/drivers/tutorial/authenticate-with-cpp-driver -> https://www.mongodb.com/docs/languages/cpp/drivers/current/configuration/#configuring-authentication
-raw: docs/drivers/cxx -> ${languages-base}/cpp/drivers/current
-raw: docs/drivers/cxx/index -> ${languages-base}/cpp/drivers/current
-raw: /docs/languages/cxx -> ${languages-base}/cpp/drivers/current
+raw: docs/drivers/tutorial/authenticate-with-cpp-driver -> ${cpp-driver-base}/configuration/#configuring-authentication
+raw: docs/drivers/cxx -> ${cpp-driver-base}
+raw: docs/drivers/cxx/index -> ${cpp-driver-base}
+raw: /docs/languages/cxx -> ${cpp-driver-base}
 
 # csharp
 
@@ -211,8 +212,8 @@ raw: docs/ecosystem/ -> ${base}/
 
 raw: docs/drivers/drivers/ -> ${base}/
 raw: docs/drivers/drivers/c/ -> ${base}/c/
-raw: docs/drivers/drivers/cxx/ -> https://www.mongodb.com/docs/languages/cpp/drivers/current/
-raw: docs/drivers/drivers/cpp/ -> https://www.mongodb.com/docs/languages/cpp/drivers/current/
+raw: docs/drivers/drivers/cxx/ -> ${cpp-driver-base}
+raw: docs/drivers/drivers/cpp/ -> ${cpp-driver-base}
 raw: docs/drivers/drivers/csharp/ -> ${base}/csharp/current/
 raw: docs/drivers/drivers/go/ -> ${base}/go/current/
 raw: docs/drivers/drivers/java/ -> ${base}/java-drivers/


### PR DESCRIPTION
Relevant output of `mut-redirects`:

```
Redirect 301 /docs/drivers/cxx https://www.mongodb.com/docs/languages/cpp/drivers/current
Redirect 301 /docs/drivers/cxx/index https://www.mongodb.com/docs/languages/cpp/drivers/current
Redirect 301 /docs/languages/cxx https://www.mongodb.com/docs/languages/cpp/drivers/current
```

# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-ecosystem/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-38350

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
- [ ] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
