### PR TITLE
fix java-rs links

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -13,7 +13,7 @@ raw: docs/drivers/go -> https://www.mongodb.com/docs/drivers/go/current/
 # Java
 
 raw: docs/drivers/java -> ${base}/java-drivers/
-raw: docs/drivers/reactive-streams/ -> https://www.mongodb.com/docs/languages/java/drivers/java-rs/current/
+raw: docs/drivers/reactive-streams/ -> https://www.mongodb.com/docs/languages/java/reactive-streams-driver/current/
 
 # Rust
 

--- a/source/java-drivers.txt
+++ b/source/java-drivers.txt
@@ -22,7 +22,7 @@ MongoDB Java Drivers
    :titlesonly:
 
    Java Sync Driver <https://www.mongodb.com/docs/drivers/java/sync/current/>
-   Java Reactive Streams Driver <https://www.mongodb.com/docs/languages/java/drivers/java-rs/current/>
+   Java Reactive Streams Driver <https://www.mongodb.com/docs/languages/java/reactive-streams-driver/current/>
 
 .. contents:: On this page
    :local:
@@ -40,7 +40,7 @@ to work with MongoDB in Java:
   for synchronous Java applications.
 
 - Use the `Java Reactive Streams Driver
-  <https://www.mongodb.com/docs/languages/java/drivers/java-rs/current/>`__
+  <https://www.mongodb.com/docs/languages/java/reactive-streams-driver/current/>`__
   to use the Reactive Streams API for asynchronous stream processing.
 
 Compatibility

--- a/source/java.txt
+++ b/source/java.txt
@@ -20,7 +20,7 @@ The `Java Sync Driver <https://www.mongodb.com/docs/drivers/java/sync/current>`_
 
 For asynchronous stream processing and reactive streams interoperability,
 the `Java Reactive Streams Driver
-<https://www.mongodb.com/docs/languages/java/drivers/java-rs/current/>`__
+<https://www.mongodb.com/docs/languages/java/reactive-streams-driver/current/>`__
 is the recommended MongoDB Java Driver.
 
 Take the free online course taught by MongoDB


### PR DESCRIPTION
# Pull Request Info

This PR fixes all links to the docs-java-rs property because of a change coming from [this PR](https://github.com/mongodb/docs-java-rs/pull/27) to correct its url path.
