### PR TITLE
DOP-4086: Correct download-and-compile-cpp-driver redirect

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -52,7 +52,7 @@ raw: docs/drivers/syntax-table -> ${base}/
 
 # cpp
 
-raw: docs/drivers/tutorial/download-and-compile-cpp-driver -> languages/installation/
+raw: docs/drivers/tutorial/download-and-compile-cpp-driver -> ${cpp-driver-base}/installation/
 raw: docs/drivers/tutorial/getting-started-with-cpp-driver -> ${cpp-driver-base}/tutorial/
 raw: docs/drivers/cpp-bson-array-examples -> ${cpp-driver-base}/working-with-bson/
 raw: docs/drivers/cpp-bson-helper-functions -> ${cpp-driver-base}/working-with-bson/


### PR DESCRIPTION
With our upcoming `mut` release, redirects rejected by AWS S3 now show the line number in the redirects file that is a problem. So, here we resolve the issue.

Pudding proof:

```
$ mut-redirects ../docs-ecosystem/config/redirects | grep docs/drivers/tutorial/download-and-compile-cpp-driver
Redirect 301 /docs/drivers/tutorial/download-and-compile-cpp-driver https://www.mongodb.com/docs/languages/cpp/cpp-driver/current/installation/
```

If this isn't the intended redirect target, we can update as needed.