### PR TITLE
DOCSP-41223 - PyMongo redirects

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -6,6 +6,7 @@ define: devhub https://www.mongodb.com/developer
 define: languages-base https://www.mongodb.com/docs/languages
 define: cpp-driver-base ${languages-base}/cpp/cpp-driver/current
 define: c-driver-base ${languages-base}/c/c-driver/current/
+define: pymongo-base ${languages-base}/python/pymongo-driver/current
 
 # Go
 
@@ -249,3 +250,7 @@ raw: docs/drivers/community-supported-drivers/ -> ${base}/
 raw:  docs/drivers/php/ -> ${base}/php-drivers/
 raw:  docs/drivers/python/ -> ${base}/python-drivers/
 raw:  docs/drivers/ruby/ -> ${base}/ruby-drivers/
+
+# Docs consolidation redirects
+
+raw: ${base}/pymongo/ -> ${pymongo-base}


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-ecosystem/blob/master/REVIEWING.md)

JIRA - https://jira.mongodb.org/browse/DOCSP-41223

Output of mut-redirects:
`Redirect 301 /https://www.mongodb.com/docs/drivers/pymongo/ https://www.mongodb.com/docs/languages/python/pymongo-driver/current`


## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
