### PR TITLE
DOCSP-41653 PHP Update Compatibility Table Refs

### DIFF
--- a/source/includes/language-compatibility-table-php.rst
+++ b/source/includes/language-compatibility-table-php.rst
@@ -1,3 +1,5 @@
+.. Full compatibility table, for reference only. 
+
 .. list-table::
    :header-rows: 1
    :stub-columns: 1

--- a/source/includes/mongodb-compatibility-table-php.rst
+++ b/source/includes/mongodb-compatibility-table-php.rst
@@ -1,3 +1,5 @@
+.. Full compatibility table, for reference only. 
+
 .. sharedinclude:: dbx/compatibility-table-legend.rst
 
 .. list-table::

--- a/source/php-drivers.txt
+++ b/source/php-drivers.txt
@@ -230,7 +230,7 @@ The first column lists the driver version.
 
 .. sharedinclude:: dbx/lifecycle-schedule-callout.rst
 
-.. include:: /includes/mongodb-compatibility-table-php.rst
+.. sharedinclude:: dbx/mongodb-compatibility-table-php.rst
 
 Language Compatibility
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -240,7 +240,7 @@ of the PHP driver for use with a specific version of PHP.
 
 The first column lists the driver versions.
 
-.. include:: /includes/language-compatibility-table-php.rst
+.. sharedinclude:: dbx/language-compatibility-table-php.rst
 
 .. include:: /includes/about-driver-compatibility.rst
 


### PR DESCRIPTION
# Pull Request Info

Linked compatibility table to the ``docs-shared`` repo. Kept a copy of full compatibility table, including legacy versions, for reference use only, as requested in ticket. 

[PR Reviewing Guidelines](https://github.com/mongodb/docs-ecosystem/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-41653>
Staging - <https://deploy-preview-995--docs-ecosystem.netlify.app/php-drivers/#compatibility>

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Did you run a spell-check?
- [x] Did you run a grammar-check?
- [x] Are all the links working?
- [x] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
