### PR TITLE
DOCSP-48223: kotlin duplicate redirect

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -255,6 +255,7 @@ raw: docs/drivers/community-supported-drivers/ -> ${base}/
 raw:  docs/drivers/php/ -> ${base}/php-drivers/
 raw:  docs/drivers/python/ -> ${base}/python-drivers/
 raw:  docs/drivers/ruby/ -> ${base}/ruby-drivers/
+raw:  docs/drivers/kotlin/ -> ${base}/kotlin-drivers/
 
 # Docs consolidation redirects
 


### PR DESCRIPTION
# Pull Request Info

[PR Reviewing Guidelines](https://github.com/mongodb/docs-ecosystem/blob/master/REVIEWING.md)

JIRA - <https://jira.mongodb.org/browse/DOCSP-48223>

```
Redirect 301 /docs/drivers/kotlin/ https://www.mongodb.com/docs/drivers/kotlin-drivers/
``` 

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Did you run a spell-check?
- [ ] Did you run a grammar-check?
- [ ] Are all the links working?
- [ ] Are the [facets and meta keywords](https://wiki.corp.mongodb.com/display/DE/Docs+Taxonomy) accurate?
